### PR TITLE
[REFACTOR] 서버코어 send 기능 Scatter-Gather 적용

### DIFF
--- a/2D_MMO_Server/DummyClient/DummyClient.cpp
+++ b/2D_MMO_Server/DummyClient/DummyClient.cpp
@@ -32,11 +32,11 @@ public:
 		char recvBuffer[4096];
 		uint8* flatbuffer = (uint8*)&buffer[4];
 		const PlayerInfo* player = GetPlayerInfo(flatbuffer);
-		//::memcpy(recvBuffer, &buffer[4], header.size - sizeof(PacketHeader));
-		//cout << recvBuffer << endl;
 		cout << "Name: " << player->name()->c_str() << " Level: " << player->level() << endl;
 
-		Send(buffer, ((PacketHeader*)buffer)->size);
+		shared_ptr<SendBuffer> sendBuffer = make_shared<SendBuffer>(4096);
+		sendBuffer->CopyBuffer(buffer, len);
+		Send(sendBuffer);
 
 		return len;
 	}

--- a/2D_MMO_Server/GameServer/ClientSession.cpp
+++ b/2D_MMO_Server/GameServer/ClientSession.cpp
@@ -19,9 +19,6 @@ int32 ClientSession::OnRecvPacket(BYTE* buffer, int32 len)
 	PacketHeader header = *((PacketHeader*)buffer);
 	cout << "Packet ID : " << header.id << " Size : " << header.size << endl;
 
-	// Echo
-	//Send(buffer, len);
-
 	return len;
 }
 

--- a/2D_MMO_Server/GameServer/ClientSessionManager.cpp
+++ b/2D_MMO_Server/GameServer/ClientSessionManager.cpp
@@ -16,11 +16,11 @@ void ClientSessionManager::Remove(shared_ptr<ClientSession> session)
 	_sessions.erase(session);
 }
 
-void ClientSessionManager::Broadcast(BYTE* buffer, int32 size)
+void ClientSessionManager::Broadcast(BYTE* buffer, int32 len)
 {
 	WRITE_LOCK;
 	for (shared_ptr<ClientSession> session : _sessions)
 	{
-		session->Send(buffer, size);
+		session->Send(buffer, len);
 	}
 }

--- a/2D_MMO_Server/GameServer/ClientSessionManager.cpp
+++ b/2D_MMO_Server/GameServer/ClientSessionManager.cpp
@@ -16,11 +16,11 @@ void ClientSessionManager::Remove(shared_ptr<ClientSession> session)
 	_sessions.erase(session);
 }
 
-void ClientSessionManager::Broadcast(BYTE* buffer, int32 len)
+void ClientSessionManager::Broadcast(shared_ptr<SendBuffer> buffer)
 {
 	WRITE_LOCK;
 	for (shared_ptr<ClientSession> session : _sessions)
 	{
-		session->Send(buffer, len);
+		session->Send(buffer);
 	}
 }

--- a/2D_MMO_Server/GameServer/ClientSessionManager.h
+++ b/2D_MMO_Server/GameServer/ClientSessionManager.h
@@ -7,7 +7,7 @@ class ClientSessionManager
 public:
 	void Add(shared_ptr<ClientSession> session);
 	void Remove(shared_ptr<ClientSession> session);
-	void Broadcast(BYTE* buffer, int32 size);
+	void Broadcast(BYTE* buffer, int32 len);
 
 private:
 	USE_LOCK;

--- a/2D_MMO_Server/GameServer/ClientSessionManager.h
+++ b/2D_MMO_Server/GameServer/ClientSessionManager.h
@@ -7,7 +7,7 @@ class ClientSessionManager
 public:
 	void Add(shared_ptr<ClientSession> session);
 	void Remove(shared_ptr<ClientSession> session);
-	void Broadcast(BYTE* buffer, int32 len);
+	void Broadcast(shared_ptr<SendBuffer> buffer);
 
 private:
 	USE_LOCK;

--- a/2D_MMO_Server/GameServer/GameServer.cpp
+++ b/2D_MMO_Server/GameServer/GameServer.cpp
@@ -29,7 +29,6 @@ int main()
 			});
 	}
 
-	//char sendData[11] = "HelloWorld";
 	flatbuffers::FlatBufferBuilder builder;
 	{
 		flatbuffers::Offset<flatbuffers::String> name = builder.CreateString("FromServer!");
@@ -41,15 +40,16 @@ int main()
 
 	while (true)
 	{
-		BYTE buffer[4096];
+		shared_ptr<SendBuffer> sendBuffer = make_shared<SendBuffer>(4096);
 
-		//((PacketHeader*)buffer)->size = (sizeof(sendData) + sizeof(PacketHeader));
+		BYTE* buffer = sendBuffer->GetBufferData();
 		((PacketHeader*)buffer)->size = (builder.GetSize() + sizeof(PacketHeader));
-		((PacketHeader*)buffer)->id = 1; // 1 : Hello Msg
-		//::memcpy(&buffer[4], sendData, sizeof(sendData));
+		((PacketHeader*)buffer)->id = 1; // temp packet ID
 		::memcpy(&buffer[4], flatbuf, builder.GetSize());
 
-		GSessionManager.Broadcast(buffer, ((PacketHeader*)buffer)->size);
+		sendBuffer->CopyBuffer(buffer, ((PacketHeader*)buffer)->size);
+
+		GSessionManager.Broadcast(sendBuffer);
 
 		this_thread::sleep_for(250ms);
 	}

--- a/2D_MMO_Server/ServerCore/CorePch.h
+++ b/2D_MMO_Server/ServerCore/CorePch.h
@@ -28,3 +28,4 @@ using namespace std;
 
 #include "Lock.h"
 #include "Session.h"
+#include "SendBuffer.h"

--- a/2D_MMO_Server/ServerCore/IocpEvent.h
+++ b/2D_MMO_Server/ServerCore/IocpEvent.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "SendBuffer.h"
 
 class Session;
 
@@ -7,7 +8,6 @@ enum class EventType : uint8
 	Connect,
 	Disconnect,
 	Accept,
-	//PreRecv,
 	Recv,
 	Send
 };
@@ -56,6 +56,5 @@ class SendEvent : public IocpEvent
 public:
 	SendEvent() : IocpEvent(EventType::Send) { }
 
-	// TEMP
-	vector<BYTE*> sendBuffers;
+	vector<shared_ptr<SendBuffer>> sendBuffers;
 };

--- a/2D_MMO_Server/ServerCore/IocpEvent.h
+++ b/2D_MMO_Server/ServerCore/IocpEvent.h
@@ -57,5 +57,5 @@ public:
 	SendEvent() : IocpEvent(EventType::Send) { }
 
 	// TEMP
-	vector<BYTE> buffer;
+	vector<BYTE*> sendBuffers;
 };

--- a/2D_MMO_Server/ServerCore/IocpEvent.h
+++ b/2D_MMO_Server/ServerCore/IocpEvent.h
@@ -56,5 +56,5 @@ class SendEvent : public IocpEvent
 public:
 	SendEvent() : IocpEvent(EventType::Send) { }
 
-	vector<shared_ptr<SendBuffer>> sendBuffers;
+	vector<shared_ptr<SendBuffer>> SendBuffers;
 };

--- a/2D_MMO_Server/ServerCore/SendBuffer.cpp
+++ b/2D_MMO_Server/ServerCore/SendBuffer.cpp
@@ -1,0 +1,35 @@
+#include "pch.h"
+#include "SendBuffer.h"
+
+SendBuffer::SendBuffer(int32 bufferSize)
+	: _writeSize(0)
+{
+	_buffer.resize(bufferSize);
+}
+
+SendBuffer::~SendBuffer()
+{
+}
+
+BYTE* SendBuffer::GetBufferData()
+{
+	return _buffer.data();
+}
+
+int32 SendBuffer::GetWriteSize()
+{
+	return _writeSize;
+}
+
+int32 SendBuffer::GetCapacity()
+{
+	return _buffer.size();
+}
+
+void SendBuffer::CopyBuffer(void* data, int32 len)
+{
+	ASSERT(GetCapacity() >= len, "SendBuffer Overflow");
+
+	::memcpy(_buffer.data(), data, len);
+	_writeSize = len;
+}

--- a/2D_MMO_Server/ServerCore/SendBuffer.h
+++ b/2D_MMO_Server/ServerCore/SendBuffer.h
@@ -1,0 +1,19 @@
+#pragma once
+
+class COREDLL SendBuffer : enable_shared_from_this<SendBuffer>
+{
+public:
+	SendBuffer(int32 bufferSize);
+	~SendBuffer();
+
+	BYTE* GetBufferData();
+	int32 GetWriteSize();
+	int32 GetCapacity();
+
+	void CopyBuffer(void* data, int32 len);
+
+private:
+	vector<BYTE> _buffer;
+	int32 _writeSize; // 실제 버퍼를 사용하는 크기. 버퍼 크기 보다 작을 수 있음
+};
+

--- a/2D_MMO_Server/ServerCore/ServerCore.vcxproj
+++ b/2D_MMO_Server/ServerCore/ServerCore.vcxproj
@@ -162,6 +162,7 @@
     <ClInclude Include="NetAddress.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="RecvBuffer.h" />
+    <ClInclude Include="SendBuffer.h" />
     <ClInclude Include="Service.h" />
     <ClInclude Include="Session.h" />
     <ClInclude Include="SocketUtils.h" />
@@ -184,6 +185,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="RecvBuffer.cpp" />
+    <ClCompile Include="SendBuffer.cpp" />
     <ClCompile Include="Service.cpp" />
     <ClCompile Include="Session.cpp" />
     <ClCompile Include="SocketUtils.cpp" />

--- a/2D_MMO_Server/ServerCore/ServerCore.vcxproj.filters
+++ b/2D_MMO_Server/ServerCore/ServerCore.vcxproj.filters
@@ -54,6 +54,9 @@
     <ClCompile Include="RecvBuffer.cpp">
       <Filter>Network</Filter>
     </ClCompile>
+    <ClCompile Include="SendBuffer.cpp">
+      <Filter>Network</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h">
@@ -102,6 +105,9 @@
       <Filter>Network</Filter>
     </ClInclude>
     <ClInclude Include="RecvBuffer.h">
+      <Filter>Network</Filter>
+    </ClInclude>
+    <ClInclude Include="SendBuffer.h">
       <Filter>Network</Filter>
     </ClInclude>
   </ItemGroup>

--- a/2D_MMO_Server/ServerCore/Session.cpp
+++ b/2D_MMO_Server/ServerCore/Session.cpp
@@ -161,14 +161,14 @@ void Session::RegisterSend()
 		shared_ptr<SendBuffer> sendBuffer = _sendQueue.front();
 
 		_sendQueue.pop();
-		_sendEvent.sendBuffers.push_back(sendBuffer);
+		_sendEvent.SendBuffers.push_back(sendBuffer);
 	}
 
 	// Scatter-Gather(데이터들을 모아서 한 번에 보낸다)
 	vector<WSABUF> wsaBufs;
-	wsaBufs.reserve(_sendEvent.sendBuffers.size());
+	wsaBufs.reserve(_sendEvent.SendBuffers.size());
 
-	for (shared_ptr<SendBuffer> sendBuffer : _sendEvent.sendBuffers)
+	for (shared_ptr<SendBuffer> sendBuffer : _sendEvent.SendBuffers)
 	{
 		WSABUF wsaBuf;
 		wsaBuf.buf = reinterpret_cast<char*>(sendBuffer->GetBufferData());
@@ -184,7 +184,7 @@ void Session::RegisterSend()
 		{
 			HandleError(errorCode);
 			_sendEvent.owner = nullptr; // 레퍼런스 카운트 감소
-			_sendEvent.sendBuffers.clear(); // 레퍼런스 카운트 감소
+			_sendEvent.SendBuffers.clear(); // 레퍼런스 카운트 감소
 			_sendRegistered.store(false);
 		}
 	}
@@ -249,7 +249,7 @@ void Session::ProcessRecv(int32 numOfBytes)
 void Session::ProcessSend(int32 numOfBytes)
 {
 	_sendEvent.owner = nullptr; // 레퍼런스 카운트 감소
-	_sendEvent.sendBuffers.clear(); // 레퍼런스 카운트 감소
+	_sendEvent.SendBuffers.clear(); // 레퍼런스 카운트 감소
 
 	if (numOfBytes == 0)
 	{

--- a/2D_MMO_Server/ServerCore/Session.cpp
+++ b/2D_MMO_Server/ServerCore/Session.cpp
@@ -16,7 +16,7 @@ Session::~Session()
 
 void Session::Send(BYTE* buffer, int32 len)
 {
-	// 현재 RegisterSend가 걸리지 않은 상태라면, 걸어준다
+	// 현재 RegisterSend가 걸리지 않은 상태라면 걸어준다
 	WRITE_LOCK;
 
 	_sendQueue.push(buffer);
@@ -65,7 +65,7 @@ void Session::Dispatch(IocpEvent* iocpEvent, int32 numOfBytes)
 		ProcessRecv(numOfBytes);
 		break;
 	case EventType::Send:
-		ProcessSend(/*static_cast<SendEvent*>(iocpEvent), */numOfBytes);
+		ProcessSend(numOfBytes);
 		break;
 	default:
 		break;
@@ -169,7 +169,7 @@ void Session::RegisterSend(int32 packetLen)
 		_sendEvent.sendBuffers.push_back(sendBuffer);
 	}
 
-	// Scatter-Gather (흩어져 있는 데이터들을 모아서 한 방에 보낸다)
+	// Scatter-Gather(데이터들을 모아서 한 번에 보낸다)
 	vector<WSABUF> wsaBufs;
 	wsaBufs.reserve(_sendEvent.sendBuffers.size());
 	for (BYTE* sendBuffer : _sendEvent.sendBuffers)
@@ -250,7 +250,7 @@ void Session::ProcessRecv(int32 numOfBytes)
 	RegisterRecv();
 }
 
-void Session::ProcessSend(/*SendEvent* sendEvent, */int32 numOfBytes)
+void Session::ProcessSend(int32 numOfBytes)
 {
 	_sendEvent.owner = nullptr; // 레퍼런스 카운트 감소
 	_sendEvent.sendBuffers.clear(); // 레퍼런스 카운트 감소

--- a/2D_MMO_Server/ServerCore/Session.cpp
+++ b/2D_MMO_Server/ServerCore/Session.cpp
@@ -16,18 +16,15 @@ Session::~Session()
 
 void Session::Send(BYTE* buffer, int32 len)
 {
-	// 문제
-	// 1) 버퍼 관리
-	// 2) sendEvent 관리(단일, 여러개, WSASend 중첩)
-
-	// TEMP
-	SendEvent* sendEvent = new SendEvent();
-	sendEvent->owner = shared_from_this(); // 레퍼런스 카운트 1 증가
-	sendEvent->buffer.resize(len);
-	::memcpy(sendEvent->buffer.data(), buffer, len);
-
+	// 현재 RegisterSend가 걸리지 않은 상태라면, 걸어준다
 	WRITE_LOCK;
-	RegisterSend(sendEvent);
+
+	_sendQueue.push(buffer);
+
+	if (_sendRegistered.exchange(true) == false)
+	{
+		RegisterSend(len);
+	}
 }
 
 bool Session::Connect()
@@ -68,7 +65,7 @@ void Session::Dispatch(IocpEvent* iocpEvent, int32 numOfBytes)
 		ProcessRecv(numOfBytes);
 		break;
 	case EventType::Send:
-		ProcessSend(static_cast<SendEvent*>(iocpEvent), numOfBytes);
+		ProcessSend(/*static_cast<SendEvent*>(iocpEvent), */numOfBytes);
 		break;
 	default:
 		break;
@@ -150,24 +147,49 @@ void Session::RegisterRecv()
 	}
 }
 
-void Session::RegisterSend(SendEvent* sendEvent)
+void Session::RegisterSend(int32 packetLen)
 {
 	if (IsConnected() == false)
 		return;
 
-	WSABUF wsaBuf;
-	wsaBuf.buf = (char*)sendEvent->buffer.data();
-	wsaBuf.len = (ULONG)sendEvent->buffer.size();
+	_sendEvent.Init();
+	_sendEvent.owner = shared_from_this(); // 레퍼런스 카운트 증가
+
+	// 보낼 데이터를 sendEvent에 등록
+	WRITE_LOCK;
+
+	int32 writeSize = 0;
+	while (_sendQueue.empty() == false)
+	{
+		BYTE* sendBuffer = _sendQueue.front();
+
+		writeSize += packetLen;
+
+		_sendQueue.pop();
+		_sendEvent.sendBuffers.push_back(sendBuffer);
+	}
+
+	// Scatter-Gather (흩어져 있는 데이터들을 모아서 한 방에 보낸다)
+	vector<WSABUF> wsaBufs;
+	wsaBufs.reserve(_sendEvent.sendBuffers.size());
+	for (BYTE* sendBuffer : _sendEvent.sendBuffers)
+	{
+		WSABUF wsaBuf;
+		wsaBuf.buf = reinterpret_cast<char*>(sendBuffer);
+		wsaBuf.len = static_cast<LONG>(packetLen);
+		wsaBufs.push_back(wsaBuf);
+	}
 
 	DWORD numOfBytes = 0;
-	if (SOCKET_ERROR == ::WSASend(_socket, &wsaBuf, 1, &numOfBytes, 0, sendEvent, nullptr))
+	if (SOCKET_ERROR == ::WSASend(_socket, wsaBufs.data(), static_cast<DWORD>(wsaBufs.size()), &numOfBytes, 0, &_sendEvent, nullptr))
 	{
 		int32 errorCode = ::WSAGetLastError();
 		if (errorCode != WSA_IO_PENDING)
 		{
 			HandleError(errorCode);
-			sendEvent->owner = nullptr; // 레퍼런스 해제
-			delete sendEvent;
+			_sendEvent.owner = nullptr; // 레퍼런스 카운트 감소
+			_sendEvent.sendBuffers.clear(); // 레퍼런스 카운트 감소
+			_sendRegistered.store(false);
 		}
 	}
 }
@@ -228,10 +250,10 @@ void Session::ProcessRecv(int32 numOfBytes)
 	RegisterRecv();
 }
 
-void Session::ProcessSend(SendEvent* sendEvent, int32 numOfBytes)
+void Session::ProcessSend(/*SendEvent* sendEvent, */int32 numOfBytes)
 {
-	sendEvent->owner = nullptr; // RELEASE_REF
-	delete sendEvent;
+	_sendEvent.owner = nullptr; // 레퍼런스 카운트 감소
+	_sendEvent.sendBuffers.clear(); // 레퍼런스 카운트 감소
 
 	if (numOfBytes == 0)
 	{
@@ -241,6 +263,16 @@ void Session::ProcessSend(SendEvent* sendEvent, int32 numOfBytes)
 
 	// 컨텐츠 코드에서 오버라이딩
 	OnSend(numOfBytes);
+
+	WRITE_LOCK;
+	if (_sendQueue.empty())
+	{
+		_sendRegistered.store(false);
+	}
+	else
+	{
+		RegisterSend(numOfBytes);
+	}
 }
 
 void Session::HandleError(int32 errorCode)

--- a/2D_MMO_Server/ServerCore/Session.h
+++ b/2D_MMO_Server/ServerCore/Session.h
@@ -53,7 +53,7 @@ private:
 	void ProcessConnect();
 	void ProcessDisconnect();
 	void ProcessRecv(int32 numOfBytes);
-	void ProcessSend(int32 numOfBytes);
+	void ProcessSend(int32 packetLen);
 		 
 	void HandleError(int32 errorCode);
 

--- a/2D_MMO_Server/ServerCore/Session.h
+++ b/2D_MMO_Server/ServerCore/Session.h
@@ -53,7 +53,7 @@ private:
 	void ProcessConnect();
 	void ProcessDisconnect();
 	void ProcessRecv(int32 numOfBytes);
-	void ProcessSend(/*SendEvent* sendEvent, */int32 numOfBytes);
+	void ProcessSend(int32 numOfBytes);
 		 
 	void HandleError(int32 errorCode);
 

--- a/2D_MMO_Server/ServerCore/Session.h
+++ b/2D_MMO_Server/ServerCore/Session.h
@@ -3,6 +3,7 @@
 #include "IocpEvent.h"
 #include "NetAddress.h"
 #include "RecvBuffer.h"
+#include "SendBuffer.h"
 
 class Service;
 
@@ -23,7 +24,7 @@ public:
 
 public:
 	// 외부에서 사용
-	void Send(BYTE* buffer, int32 len);
+	void Send(shared_ptr<SendBuffer> sendBuffer);
 	bool Connect();
 	void Disconnect(const WCHAR* cause);
 
@@ -48,7 +49,7 @@ private:
 	bool RegisterConnect();
 	bool RegisterDisconnect();
 	void RegisterRecv();
-	void RegisterSend(int32 numOfBytes);
+	void RegisterSend();
 		 
 	void ProcessConnect();
 	void ProcessDisconnect();
@@ -77,7 +78,7 @@ private:
 	RecvBuffer _recvBuffer;
 
 	// 송신
-	queue<BYTE*> _sendQueue;
+	queue<shared_ptr<SendBuffer>> _sendQueue;
 	atomic<bool> _sendRegistered = false;
 
 private:

--- a/2D_MMO_Server/ServerCore/Session.h
+++ b/2D_MMO_Server/ServerCore/Session.h
@@ -48,12 +48,12 @@ private:
 	bool RegisterConnect();
 	bool RegisterDisconnect();
 	void RegisterRecv();
-	void RegisterSend(SendEvent* sendEvent);
+	void RegisterSend(int32 numOfBytes);
 		 
 	void ProcessConnect();
 	void ProcessDisconnect();
 	void ProcessRecv(int32 numOfBytes);
-	void ProcessSend(SendEvent* sendEvent, int32 numOfBytes);
+	void ProcessSend(/*SendEvent* sendEvent, */int32 numOfBytes);
 		 
 	void HandleError(int32 errorCode);
 
@@ -77,12 +77,15 @@ private:
 	RecvBuffer _recvBuffer;
 
 	// 송신
+	queue<BYTE*> _sendQueue;
+	atomic<bool> _sendRegistered = false;
 
 private:
 	// IocpEvent 재사용
 	ConnectEvent _connectEvent;
 	DisconnectEvent _disconnectEvent;
 	RecvEvent _recvEvent;
+	SendEvent _sendEvent;
 };
 
 // PacketSession


### PR DESCRIPTION
## 📝 변경사항

서버코어 send 기능
큐를 이용해 패킷들을 모아서 한 번에 보내는 Scatter-Gather 적용

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 참고사항

1) shared_ptr<SendBuffer> sendBuffer = make_shared<SendBuffer>(4096);

2) BYTE* buffer = sendBuffer->GetBufferData();
((PacketHeader*)buffer)->size = (builder.GetSize() + sizeof(PacketHeader));
((PacketHeader*)buffer)->id = 1; // temp packet ID
::memcpy(&buffer[4], flatbuf, builder.GetSize());

3) sendBuffer->CopyBuffer(buffer, ((PacketHeader*)buffer)->size);

4) GSessionManager.Broadcast(sendBuffer);

// 1. sendbuffer의 크기를 정해서 객체를 생성한다.
// 2. 임시 버퍼 객체에 데이터를 채운다.
// 3. sendBuffer의 CopyBuffer를 사용해 임시 버퍼를 sendBuffer로 복사한다.
// 4. 전송할 sendBuffer를 Broadcast나 Send함수를 사용해 전송한다.