### PR TITLE
[ADD] BaseRef 스마트 포인터 유틸 클래스 추가

### DIFF
--- a/2D_MMO_Server/ServerCore/Array.h
+++ b/2D_MMO_Server/ServerCore/Array.h
@@ -4,7 +4,7 @@ using uint32 = unsigned int;
 
 namespace Utils
 {
-	class Array
+	class COREDLL Array
 	{
 	public:
 		template <typename T>

--- a/2D_MMO_Server/ServerCore/Array.h
+++ b/2D_MMO_Server/ServerCore/Array.h
@@ -1,0 +1,28 @@
+#pragma once
+
+using uint32 = unsigned int;
+
+namespace Utils
+{
+	class Array
+	{
+	public:
+		template <typename T>
+		static void Copy(T* src, uint32 srcIndex, T* destination, uint32 destIndex, uint32 length) {
+			for (uint32 i = 0; i < length; i++)
+				destination[i + destIndex] = src[i + srcIndex];
+		}
+		template <typename T>
+		static void Copy(T* src, uint32 srcIndex, T* destination, uint32 length) {
+			Copy(src, srcIndex, destination, 0, length);
+		}
+		template <typename T>
+		static void Copy(T* src, T* destination, uint32 destIndex, uint32 length) {
+			Copy(src, 0, destination, destIndex, length);
+		}
+		template <typename T>
+		static void Copy(T* src, T* destination, uint32 length) {
+			Copy(src, 0, destination, 0, length);
+		}
+	};
+}

--- a/2D_MMO_Server/ServerCore/CoreRef.h
+++ b/2D_MMO_Server/ServerCore/CoreRef.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "pch.h"
+#include "Array.h"
+
+template <class _Ty>
+class COREDLL BaseRef : public enable_shared_from_this<BaseRef<_Ty>> {
+private:
+	vector<_Ty> _data;
+
+public:
+	virtual ~BaseRef() {}
+
+public:
+	const uint32 Size() const { return _data.size(); }
+
+public:
+	void Reserve(uint32 size) { Assign(size); }
+	void Assign(uint32 size, _Ty defaultVal = (_Ty)0) { _data.assign(size, defaultVal); }
+	void Copy(vector<_Ty>& target) { Copy(target.data(), target.size()); }
+	void Copy(_Ty* data, uint32 size) {
+		_data.clear();
+		Assign(size);
+		Utils::Array::Copy(data, _data.data(), size);
+	}
+	shared_ptr<BaseRef<_Ty>> GetPtr() { return this->shared_from_this(); }
+
+public:
+	operator _Ty* () { return _data.data(); }
+	_Ty& operator[] (const uint32 i) { return _data[i]; }
+};

--- a/2D_MMO_Server/ServerCore/ServerCore.vcxproj
+++ b/2D_MMO_Server/ServerCore/ServerCore.vcxproj
@@ -151,10 +151,12 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="Array.h" />
     <ClInclude Include="BitConverter.h" />
     <ClInclude Include="CoreGlobal.h" />
     <ClInclude Include="CoreMacro.h" />
     <ClInclude Include="CorePch.h" />
+    <ClInclude Include="CoreRef.h" />
     <ClInclude Include="CoreTLS.h" />
     <ClInclude Include="IocpCore.h" />
     <ClInclude Include="IocpEvent.h" />

--- a/2D_MMO_Server/ServerCore/ServerCore.vcxproj.filters
+++ b/2D_MMO_Server/ServerCore/ServerCore.vcxproj.filters
@@ -119,5 +119,11 @@
     <ClInclude Include="BitConverter.h">
       <Filter>Utils</Filter>
     </ClInclude>
+    <ClInclude Include="Array.h">
+      <Filter>Utils</Filter>
+    </ClInclude>
+    <ClInclude Include="CoreRef.h">
+      <Filter>Main</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## 📝 변경사항

스마트 포인터 유틸 클래스인 BaseRef 클래스 및 버퍼 복사 유틸 클래스인 Array 클래스 추가

주 사용처는 나중에 추가될 PacketManager, PacketHandler 클래스입니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 참고사항

ex) using ByteRef = shared_ptr<BaseRef<std::byte>>;

## API

내부 버퍼 크기 반환
```
const uint32 Size() const;
```

내부 버퍼 Assign (모든 인덱스가 0으로 초기화됨)
```
void Reserve(uint32);
```

내부 버퍼 할당 및 T로 초기화
```
void Assign(uint32, T = 0);
```
내부 버퍼 target으로 초기화
```
void Copy(vector<T>& target;
```
내부 버퍼에 T*를 size만큼 할당 및 복사
```
void Copy(T*, uint);
```
shared_from_this로 자기 자신을 반환
```
shared_ptr<BaseRef<T>> GetPtr;
```
내부 버퍼 포인터 반환
```
operator T*();
```
내부 버퍼 인덱스값 반환
```
T& operator[] (const uint32);
```

