### PR TITLE
[FIX] CoreGlobal 헤더 참조 누락 수정

### DIFF
--- a/2D_MMO_Server/ServerCore/CoreGlobal.h
+++ b/2D_MMO_Server/ServerCore/CoreGlobal.h
@@ -1,4 +1,6 @@
 #pragma once
 
+#include "pch.h"
+
 COREDLL extern class ThreadManager* GThreadManager;
 COREDLL extern class PoolManager* GPoolManager;


### PR DESCRIPTION
## 📝 변경사항

미리 컴파일된 헤더 (pch.h) 참조 부분 누락으로 인한 빌드 오류 수정

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 참고사항

CoreGlobal에 누락된 #include "pch.h" 추가
