### PR TITLE
[ADD] 맵 데이터 변환 툴 추가

### DIFF
--- a/2D_MMO.sln
+++ b/2D_MMO.sln
@@ -3,6 +3,8 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Assembly-CSharp", "Assembly-CSharp.csproj", "{2ECC457B-661D-99FB-3556-F01DC903DA44}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Assembly-CSharp-Editor", "Assembly-CSharp-Editor.csproj", "{48CC2BF2-A634-F6F6-80D7-1099CA6F2C1D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -13,6 +15,10 @@ Global
 		{2ECC457B-661D-99FB-3556-F01DC903DA44}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2ECC457B-661D-99FB-3556-F01DC903DA44}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2ECC457B-661D-99FB-3556-F01DC903DA44}.Release|Any CPU.Build.0 = Release|Any CPU
+		{48CC2BF2-A634-F6F6-80D7-1099CA6F2C1D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{48CC2BF2-A634-F6F6-80D7-1099CA6F2C1D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{48CC2BF2-A634-F6F6-80D7-1099CA6F2C1D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{48CC2BF2-A634-F6F6-80D7-1099CA6F2C1D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Assembly-CSharp-Editor.csproj
+++ b/Assembly-CSharp-Editor.csproj
@@ -10,7 +10,7 @@
     <ProductVersion>10.0.20506</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <RootNamespace></RootNamespace>
-    <ProjectGuid>{EA36A84C-EAB0-207A-7DD3-167C7D8BAED5}</ProjectGuid>
+    <ProjectGuid>{48CC2BF2-A634-F6F6-80D7-1099CA6F2C1D}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <AssemblyName>Assembly-CSharp-Editor</AssemblyName>
@@ -61,42 +61,7 @@
     <Analyzer Include="C:\Program Files\Unity\Hub\Editor\6000.0.23f1\Editor\Data\Tools\Unity.SourceGenerators\Unity.UIToolkit.SourceGenerator.dll" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Assets\#NVJOB Water Shaders V2\Example Scenes\PostProcessing\Editor\Attributes\PostProcessingModelEditorAttribute.cs" />
-    <Compile Include="Assets\#NVJOB Water Shaders V2\Example Scenes\PostProcessing\Editor\Models\ChromaticAberrationEditor.cs" />
-    <Compile Include="Assets\#NVJOB Water Shaders V2\Example Scenes\PostProcessing\Editor\PostProcessingBehaviourEditor.cs" />
-    <Compile Include="Assets\#NVJOB Water Shaders V2\Example Scenes\PostProcessing\Editor\Models\MotionBlurModelEditor.cs" />
-    <Compile Include="Assets\#NVJOB Water Shaders V2\Example Scenes\PostProcessing\Editor\PostProcessingModelEditor.cs" />
-    <Compile Include="Assets\#NVJOB Water Shaders V2\Example Scenes\PostProcessing\Editor\PostProcessingFactory.cs" />
-    <Compile Include="Assets\#NVJOB Water Shaders V2\Example Scenes\PostProcessing\Editor\Monitors\VectorscopeMonitor.cs" />
-    <Compile Include="Assets\#NVJOB Water Shaders V2\Example Scenes\PostProcessing\Editor\Models\AntialiasingModelEditor.cs" />
-    <Compile Include="Assets\#NVJOB Water Shaders V2\Example Scenes\PostProcessing\Editor\Models\GrainModelEditor.cs" />
-    <Compile Include="Assets\#NVJOB Water Shaders V2\Example Scenes\PostProcessing\Editor\Monitors\ParadeMonitor.cs" />
-    <Compile Include="Assets\#NVJOB Water Shaders V2\Example Scenes\PostProcessing\Editor\Utils\CurveEditor.cs" />
-    <Compile Include="Assets\#NVJOB Water Shaders V2\Example Scenes\PostProcessing\Editor\Models\ColorGradingModelEditor.cs" />
-    <Compile Include="Assets\#NVJOB Water Shaders V2\Example Scenes\PostProcessing\Editor\PropertyDrawers\MinDrawer.cs" />
-    <Compile Include="Assets\#NVJOB Water Shaders V2\Example Scenes\PostProcessing\Editor\PostProcessingMonitor.cs" />
-    <Compile Include="Assets\#NVJOB Water Shaders V2\Example Scenes\PostProcessing\Editor\Models\ScreenSpaceReflectionModelEditor.cs" />
-    <Compile Include="Assets\#NVJOB Water Shaders V2\Example Scenes\PostProcessing\Editor\PostProcessingInspector.cs" />
-    <Compile Include="Assets\#NVJOB Water Shaders V2\Example Scenes\PostProcessing\Editor\Models\UserLutModelEditor.cs" />
-    <Compile Include="Assets\#NVJOB Water Shaders V2\Example Scenes\PostProcessing\Editor\Monitors\HistogramMonitor.cs" />
-    <Compile Include="Assets\#NVJOB Water Shaders V2\Example Scenes\PostProcessing\Editor\Models\BloomModelEditor.cs" />
-    <Compile Include="Assets\#NVJOB Water Shaders V2\Example Scenes\PostProcessing\Editor\Models\FogModelEditor.cs" />
-    <Compile Include="Assets\#NVJOB Water Shaders V2\Example Scenes\PostProcessing\Editor\PropertyDrawers\GetSetDrawer.cs" />
-    <Compile Include="Assets\#NVJOB Water Shaders V2\#NVJOB Water Shaders V2\Editor\NVWaterMaterials.cs" />
-    <Compile Include="Assets\#NVJOB Water Shaders V2\Example Scenes\PostProcessing\Editor\Utils\ReflectionUtils.cs" />
-    <Compile Include="Assets\#NVJOB Water Shaders V2\Example Scenes\PostProcessing\Editor\PropertyDrawers\TrackballGroupDrawer.cs" />
-    <Compile Include="Assets\#NVJOB Water Shaders V2\Example Scenes\PostProcessing\Editor\Models\VignetteModelEditor.cs" />
-    <Compile Include="Assets\#NVJOB Water Shaders V2\Example Scenes\PostProcessing\Editor\Models\BuiltinDebugViewsEditor.cs" />
-    <Compile Include="Assets\#NVJOB Water Shaders V2\Example Scenes\PostProcessing\Editor\Models\EyeAdaptationModelEditor.cs" />
-    <Compile Include="Assets\#NVJOB Water Shaders V2\Example Scenes\PostProcessing\Editor\Monitors\WaveformMonitor.cs" />
-    <Compile Include="Assets\#NVJOB Water Shaders V2\Example Scenes\PostProcessing\Editor\Models\DepthOfFieldModelEditor.cs" />
-    <Compile Include="Assets\#NVJOB Water Shaders V2\Example Scenes\PostProcessing\Editor\Utils\EditorGUIHelper.cs" />
-    <Compile Include="Assets\#NVJOB Water Shaders V2\Example Scenes\PostProcessing\Editor\Models\AmbientOcclusionModelEditor.cs" />
-    <Compile Include="Assets\#NVJOB Water Shaders V2\Example Scenes\PostProcessing\Editor\Models\DefaultPostFxModelEditor.cs" />
-    <Compile Include="Assets\#NVJOB Water Shaders V2\Example Scenes\PostProcessing\Editor\Utils\FxStyles.cs" />
-    <Compile Include="Assets\#NVJOB Water Shaders V2\Example Scenes\PostProcessing\Editor\Models\DitheringModelEditor.cs" />
-    <Compile Include="Assets\#NVJOB Water Shaders V2\Example Scenes\Environment\#NVJOB Assets\Dynamic Sky (For Demo)\Editor\NVDSkyDemoMaterials.cs" />
-    <Compile Include="Assets\#NVJOB Water Shaders V2\Example Scenes\PostProcessing\Editor\Utils\EditorResources.cs" />
+    <Compile Include="Assets\Editor\MapTool.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="UnityEngine">
@@ -579,10 +544,6 @@
       <HintPath>C:\Program Files\Unity\Hub\Editor\6000.0.23f1\Editor\Data\PlaybackEngines\WindowsStandaloneSupport\UnityEditor.WindowsStandalone.Extensions.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="UnityEditor.Android.Extensions">
-      <HintPath>C:\Program Files\Unity\Hub\Editor\6000.0.23f1\Editor\Data\PlaybackEngines\AndroidPlayer\UnityEditor.Android.Extensions.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="Unity.VisualScripting.YamlDotNet">
       <HintPath>Library\PackageCache\com.unity.visualscripting\Editor\VisualScripting.Core\Dependencies\YamlDotNet\Unity.VisualScripting.YamlDotNet.dll</HintPath>
       <Private>False</Private>
@@ -625,14 +586,6 @@
     </Reference>
     <Reference Include="Mono.Cecil">
       <HintPath>Library\PackageCache\com.unity.nuget.mono-cecil\Mono.Cecil.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Unity.Android.Types">
-      <HintPath>C:\Program Files\Unity\Hub\Editor\6000.0.23f1\Editor\Data\PlaybackEngines\AndroidPlayer\Unity.Android.Types.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Unity.Android.Gradle">
-      <HintPath>C:\Program Files\Unity\Hub\Editor\6000.0.23f1\Editor\Data\PlaybackEngines\AndroidPlayer\Unity.Android.Gradle.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="mscorlib">
@@ -1434,16 +1387,8 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="Assembly-CSharp.csproj">
-      <Project>{F1933D40-E0EE-AD99-8F70-86A485CDC7D4}</Project>
+      <Project>{2ECC457B-661D-99FB-3556-F01DC903DA44}</Project>
       <Name>Assembly-CSharp</Name>
-    </ProjectReference>
-    <ProjectReference Include="FangAutoTile.Editor.csproj">
-      <Project>{E334B3F4-0F8B-A78F-C9A0-8E72A937D9FD}</Project>
-      <Name>FangAutoTile.Editor</Name>
-    </ProjectReference>
-    <ProjectReference Include="FangAutoTile.csproj">
-      <Project>{82EAD07D-F932-7D07-1A0D-E440E0E5382C}</Project>
-      <Name>FangAutoTile</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Assets/Editor.meta
+++ b/Assets/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ae4d17c089dc04846a651b333472b81d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/MapTool.cs
+++ b/Assets/Editor/MapTool.cs
@@ -1,0 +1,56 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Tilemaps;
+using System.IO;
+
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
+public class MapEditor
+{
+#if UNITY_EDITOR
+
+    [MenuItem("Tools/GenerateMap")]
+    private static void GenerateMap()
+    {
+        bool result = EditorUtility.DisplayDialog("MapTool", "Are you sure want to generate the map data?", "Ok", "Cancel");
+
+        if(result)
+        {
+            GameObject[] gameObjects = Resources.LoadAll<GameObject>("Prefabs/Maps");
+
+            foreach (GameObject go in gameObjects)
+            {
+                Tilemap tmBase = Utils.FindChild<Tilemap>(go, "BG");
+                Tilemap tm = Utils.FindChild<Tilemap>(go, "Collision");
+
+                using (var writer = File.CreateText($"Assets/Resources/MapData/{go.name}.txt"))
+                {
+                    writer.WriteLine(tmBase.cellBounds.xMin);
+                    writer.WriteLine(tmBase.cellBounds.xMax);
+                    writer.WriteLine(tmBase.cellBounds.yMin);
+                    writer.WriteLine(tmBase.cellBounds.yMax);
+
+                    for (int y = tmBase.cellBounds.yMax - 1; y >= tmBase.cellBounds.yMin; y--)
+                    {
+                        for (int x = tmBase.cellBounds.xMin; x < tmBase.cellBounds.xMax; x++)
+                        {
+                            TileBase tile = tm.GetTile(new Vector3Int(x, y, 0));
+                            if (tile != null)
+                                writer.Write("1");
+                            else
+                                writer.Write("0");
+                        }
+                        writer.WriteLine();
+                    }
+                }
+            }
+
+            EditorUtility.DisplayDialog("MapTool", "Map data generated successfully!", "Ok");
+        }
+    }
+#endif
+
+}

--- a/Assets/Editor/MapTool.cs.meta
+++ b/Assets/Editor/MapTool.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2c7c7d1e00bead54fb8794b55c37ac0f

--- a/Assets/Resources/MapData.meta
+++ b/Assets/Resources/MapData.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cbef1a8e944fd834695bf4492eec0d99
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Utils/Utils.cs
+++ b/Assets/Scripts/Utils/Utils.cs
@@ -1,16 +1,40 @@
 using UnityEngine;
 
-public class Utils : MonoBehaviour
+public class Utils
 {
-    // Start is called once before the first execution of Update after the MonoBehaviour is created
-    void Start()
+    public static GameObject FindChild(GameObject go, string name)
     {
-        
+        Transform transform = FindChild<Transform>(go, name);
+
+        if(transform == null)
+        {
+            return null;
+        }
+
+        return transform.gameObject;
     }
 
-    // Update is called once per frame
-    void Update()
+    public static T FindChild<T>(GameObject go, string name) where T : Object
     {
-        
+        if(go == null)
+        {
+            return null;
+        }
+
+        for(int i = 0; i < go.transform.childCount; i++)
+        {
+            Transform transform = go.transform.GetChild(i);
+
+            if(string.IsNullOrEmpty(name) || transform.name == name)
+            {
+                T component = transform.GetComponent<T>();
+                if(component != null)
+                {
+                    return component;
+                }
+            }
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
## 📝 변경사항

타일 맵을 0(갈 수 있는 부분)과 1(갈 수 없는 부분)로 구분하여 텍스트 파일로 저장하는 유니티 에디터 추가

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 참고사항

1. 제작한 타일 맵을 Resources/Prefabs/Maps 경로에 저장

2. 유니티 엔진 상단 메뉴에서 Tools/GenerateMap 클릭
![Screenshot 2025-02-05 153219](https://github.com/user-attachments/assets/bcb8af86-85ca-4945-94bc-a4f3380ad8f4)

3. GenerateMap을 클릭하면 맵 데이터를 생성할 것인지 확인 메시지 출력
![Screenshot 2025-02-05 153233](https://github.com/user-attachments/assets/c5cc5d98-9c10-4e08-a362-b1c9b6d83a4a)

4. 맵 데이터 모두 생성 후 아래 메시지 확인
![Screenshot 2025-02-05 153244](https://github.com/user-attachments/assets/b28ef0d3-a1f0-4916-b7cb-570b5b1540f6)

5. Prefabs/MapData 경로에서 생성된 파일 확인
![Screenshot 2025-02-05 153415](https://github.com/user-attachments/assets/6703fad2-25d8-44f6-8c23-ff5caeae3e8f)