### PR TITLE
[FIX] 유니티 에디터 플레이 모드 종료 시 서버와 연결 끊기지 않는 문제(#45 이슈)

### DIFF
--- a/2D_MMO_Server/ServerCore_Client/ServerCore/Session.cs
+++ b/2D_MMO_Server/ServerCore_Client/ServerCore/Session.cs
@@ -131,7 +131,7 @@ namespace ServerCore
                 Disconnect();
             }
         }
-        void Disconnect()
+        public void Disconnect()
         {
             if (Interlocked.Exchange(ref _disconnect, 1) == 1)
                 return;


### PR DESCRIPTION
## 📝 변경사항

유니티 플레이 모드 종료 시 서버와 연결 끊기지 않는 문제 해결

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [X] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 참고사항

#45 이슈 문제 해결을 위한 수정입니다.

유니티 에디터의 플레이 모드 종료 시 서버와 연결이 끊어지지 않는 문제가 있어 플레이어 스폰 문제가 발생했습니다.

문제 해결을 위해 클라이언트에서 서버와의 연결을 직접적으로 끊어주려고 클라이언트 서버코어의 Disconnect() 함수를 클라이언트 코드에서 사용할 수 있도록 수정하였습니다.

클라이언트 서버코어 재빌드를 하고 유니티에 붙여넣은 후 프로젝트를 진행해주시면 감사하겠습니다.
