### PR TITLE
[ADD] 서버 이동 검증

### DIFF
--- a/2D_MMO_Server/GameServer/GameRoom.h
+++ b/2D_MMO_Server/GameServer/GameRoom.h
@@ -2,21 +2,29 @@
 #include "pch.h"
 
 class Player;
+class Map;
 
 class GameRoom : public enable_shared_from_this<GameRoom>
 {
 public:
-	int32 GetRoomId() const;
-	void SetRoomId(int32 roomId);
+	GameRoom();
+	~GameRoom() = default;
+
+public:
+	void Init(int32 mapId);
 	void EnterGame(shared_ptr<Player> newPlayer);
 	void LeaveGame(int32 playerId);
 	void HandleMove(shared_ptr<Player> player, const C_MOVE* movePkt);
 	void HandleSkill(shared_ptr<Player> player, const C_SKILL* skillPkt);
 	void Broadcast(SendBufferRef buffer);
 
+public:
+	int32 GetRoomId() const;
+	void SetRoomId(int32 roomId);
+
 private:
 	USE_LOCK;
 	int32 _roomId;
 	map<uint32, shared_ptr<Player>> _players;
+	shared_ptr<Map> _map;
 };
-

--- a/2D_MMO_Server/GameServer/GameServer.cpp
+++ b/2D_MMO_Server/GameServer/GameServer.cpp
@@ -28,7 +28,7 @@ int main()
 	//}
 
 	// GameServer Listening
-	RoomManager::Instance().Add();
+	RoomManager::Instance().Add(1); // Temp 1¹ø ¸Ê ·Îµå
 
 	shared_ptr<ServerService> service = std::make_shared<ServerService>(
 		NetAddress(L"127.0.0.1", 8002),

--- a/2D_MMO_Server/GameServer/GameServer.vcxproj
+++ b/2D_MMO_Server/GameServer/GameServer.vcxproj
@@ -180,6 +180,7 @@
     <ClCompile Include="DBSession.cpp" />
     <ClCompile Include="GameRoom.cpp" />
     <ClCompile Include="GameServer.cpp" />
+    <ClCompile Include="Map.cpp" />
     <ClCompile Include="PacketHandler.cpp" />
     <ClCompile Include="PacketManager.cpp" />
     <ClCompile Include="pch.cpp">
@@ -193,10 +194,13 @@
     <ClCompile Include="RoomManager.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="Chat_generated.h" />
     <ClInclude Include="ClientSession.h" />
     <ClInclude Include="ClientSessionManager.h" />
     <ClInclude Include="DBSession.h" />
     <ClInclude Include="GameRoom.h" />
+    <ClInclude Include="InGame_generated.h" />
+    <ClInclude Include="Map.h" />
     <ClInclude Include="PacketHandler.h" />
     <ClInclude Include="PacketManager.h" />
     <ClInclude Include="pch.h" />
@@ -204,7 +208,6 @@
     <ClInclude Include="PlayerManager.h" />
     <ClInclude Include="Protocol_generated.h" />
     <ClInclude Include="RoomManager.h" />
-    <ClInclude Include="Test_generated.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/2D_MMO_Server/GameServer/GameServer.vcxproj.filters
+++ b/2D_MMO_Server/GameServer/GameServer.vcxproj.filters
@@ -54,6 +54,9 @@
     <ClCompile Include="RoomManager.cpp">
       <Filter>Game</Filter>
     </ClCompile>
+    <ClCompile Include="Map.cpp">
+      <Filter>Game</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h">
@@ -74,12 +77,6 @@
     <ClInclude Include="DBSession.h">
       <Filter>Session</Filter>
     </ClInclude>
-    <ClInclude Include="Protocol_generated.h">
-      <Filter>Protocol</Filter>
-    </ClInclude>
-    <ClInclude Include="Test_generated.h">
-      <Filter>Protocol</Filter>
-    </ClInclude>
     <ClInclude Include="GameRoom.h">
       <Filter>Game</Filter>
     </ClInclude>
@@ -91,6 +88,18 @@
     </ClInclude>
     <ClInclude Include="RoomManager.h">
       <Filter>Game</Filter>
+    </ClInclude>
+    <ClInclude Include="Map.h">
+      <Filter>Game</Filter>
+    </ClInclude>
+    <ClInclude Include="InGame_generated.h">
+      <Filter>Protocol</Filter>
+    </ClInclude>
+    <ClInclude Include="Protocol_generated.h">
+      <Filter>Protocol</Filter>
+    </ClInclude>
+    <ClInclude Include="Chat_generated.h">
+      <Filter>Protocol</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/2D_MMO_Server/GameServer/Map.cpp
+++ b/2D_MMO_Server/GameServer/Map.cpp
@@ -1,0 +1,113 @@
+#include "pch.h"
+#include <fstream>
+#include "Map.h"
+#include "Player.h"
+
+Map::Map()
+	: _minX(0)
+	, _maxX(0)
+	, _minY(0)
+	, _maxY(0)
+{
+}
+
+bool Map::CanGo(Vector2Int cellPos, bool checkObjects)
+{
+	if (cellPos.X < GetMinX() || cellPos.X > GetMaxX())
+	{
+		return false;
+	}
+	if (cellPos.Y < GetMinY() || cellPos.Y > GetMaxY())
+	{
+		return false;
+	}
+
+	int32 x = cellPos.X - GetMinX();
+	int32 y = GetMaxY() - cellPos.Y;
+	return !_collision[y][x] && (!checkObjects || _players[y][x] == nullptr);
+}
+
+bool Map::ApplyMove(shared_ptr<Player> player, Vector2Int dest)
+{
+	if (player->GetPlayerPosX() < GetMinX() || player->GetPlayerPosX() > GetMaxX())
+	{
+		return false;
+	}
+	if (player->GetPlayerPosY() < GetMinY() || player->GetPlayerPosY() > GetMaxY())
+	{
+		return false;
+	}
+	if (CanGo(dest, true) == false)
+	{
+		return false;
+	}
+
+	// 서버가 가지고 있는 맵 정보(좌표)에 플레이어 저장
+	{
+		int32 x = player->GetPlayerPosX() - GetMinX();
+		int32 y = GetMaxY() - player->GetPlayerPosY();
+		if (_players[y][x] == player)
+		{
+			_players[y][x] = nullptr;
+		}
+	}
+	{
+		int32 x = dest.X - GetMinX();
+		int32 y = GetMaxY() - dest.Y;
+		_players[y][x] = player;
+	}
+
+	// 실제 좌표 이동
+	player->SetPlayerPosX(dest.X);
+	player->SetPlayerPosY(dest.Y);
+	return true;
+}
+
+void Map::LoadMap(int32 mapId, string path)
+{
+	// 아이디에 따라 맵 파일 이름 저장. 예) Map_001.txt
+	string mapNum = to_string(mapId);
+	size_t mapNumSize = 3;
+
+	size_t zeroPadding = mapNumSize - min(mapNumSize, mapNum.size());
+	mapNum.insert(0, zeroPadding, '0');
+
+	string mapName = "Map_" + mapNum;
+	string mapFilepath = path + "/" + mapName + ".txt";
+
+	// 경로에 있는 맵 파일 한 줄씩 로드
+	ifstream file(mapFilepath, ios_base::in);
+	if (file.is_open())
+	{
+		string line;
+		getline(file, line);
+		SetMinX(stoi(line));
+		getline(file, line);
+		SetMaxX(stoi(line) - 1);
+		getline(file, line);
+		SetMinY(stoi(line));
+		getline(file, line);
+		SetMaxY(stoi(line) - 1);
+
+		int32 xCount = GetMaxX() - GetMinX() + 1;
+		int32 yCount = GetMaxY() - GetMinY() + 1;
+
+		InitMatrix(_collision, xCount, yCount);
+		InitMatrix(_players, xCount, yCount);
+
+		for (int32 y = 0; y < yCount; y++)
+		{
+			getline(file, line);
+			for (int32 x = 0; x < xCount; x++)
+			{
+				_collision[y][x] = (line[x] == '1' ? true : false);
+			}
+		}
+	}
+	else
+	{
+		cout << "Not Found Files!" << endl;
+		CRASH();
+		return;
+	}
+}

--- a/2D_MMO_Server/GameServer/Map.h
+++ b/2D_MMO_Server/GameServer/Map.h
@@ -1,0 +1,65 @@
+#pragma once
+#include "pch.h"
+
+class Player;
+
+struct Vector2Int
+{
+	Vector2Int(int32 x, int32 y)
+	{
+		this->X = x;
+		this->Y = y;
+	}
+
+	static Vector2Int Up() { return Vector2Int(0, 1); }
+	static Vector2Int Down() { return Vector2Int(0, -1); }
+	static Vector2Int Left() { return Vector2Int(-1, 0); }
+	static Vector2Int Right() { return Vector2Int(1, 0); }
+
+	friend Vector2Int operator+(Vector2Int a, Vector2Int b)
+	{
+		return Vector2Int(a.X + b.X, a.Y + b.Y);
+	}
+
+	int32 X;
+	int32 Y;
+};
+
+class Map
+{
+public:
+	Map();
+	~Map() = default;
+
+public:
+	bool CanGo(Vector2Int cellPos, bool checkObjects = true);
+	bool ApplyMove(shared_ptr<Player> player, Vector2Int dest);
+	void LoadMap(int32 mapId, string path = "../../Common/MapData");
+
+	template<typename T>
+	void InitMatrix(vector<vector<T>>& matrix, uint32 x, uint32 y)
+	{
+		vector<T> colMatrix;
+		colMatrix.assign(x, 0);
+		matrix.assign(y, colMatrix);
+	}
+
+public:
+	int32 GetMinX() const { return _minX; }
+	int32 GetMaxX() const { return _maxX; }
+	int32 GetMinY() const { return _minY; }
+	int32 GetMaxY() const { return _maxY; }
+	void SetMinX(int32 x) { _minX = x; }
+	void SetMaxX(int32 x) { _maxX = x; }
+	void SetMinY(int32 y) { _minY = y; }
+	void SetMaxY(int32 y) { _maxY = y; }
+
+private:
+	int32 _minX;
+	int32 _maxX;
+	int32 _minY;
+	int32 _maxY;
+
+	vector<vector<bool>> _collision;
+	vector<vector<shared_ptr<Player>>> _players;
+};

--- a/2D_MMO_Server/GameServer/Player.cpp
+++ b/2D_MMO_Server/GameServer/Player.cpp
@@ -1,6 +1,18 @@
 #include "pch.h"
 #include "Player.h"
 
+Player::Player() 
+	: _id(0)
+	, _posX(0)
+	, _posY(0)
+	, _state(ObjectState_IDLE)
+	, _moveDir(MoveDir_NONE)
+	, _cellPos(0, 0)
+	, _room(nullptr)
+	, _session(nullptr)
+{
+}
+
 shared_ptr<GameRoom> Player::GetGameRoom() const
 {
 	return _room;
@@ -19,41 +31,6 @@ shared_ptr<ClientSession> Player::GetClientSession() const
 void Player::SetClientSession(shared_ptr<ClientSession> session)
 {
 	_session = session;
-}
-
-int32 Player::GetPlayerId() const
-{
-	return _id;
-}
-
-std::string Player::GetPlayerName() const
-{
-	return _name;
-}
-
-int32 Player::GetPlayerPosX() const
-{
-	return _posX;
-}
-
-int32 Player::GetPlayerPosY() const
-{
-	return _posY;
-}
-
-ObjectState Player::GetPlayerState() const
-{
-	return _state;
-}
-
-MoveDir Player::GetPlayerMoveDir() const
-{
-	return _moveDir;
-}
-
-void Player::SetPlayerId(int32 id)
-{
-	_id = id;
 }
 
 void Player::SetPlayerInfo(int32 id, std::string name, int32 posX, int32 posY, ObjectState state, MoveDir moveDir)

--- a/2D_MMO_Server/GameServer/Player.h
+++ b/2D_MMO_Server/GameServer/Player.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "Map.h"
 
 class GameRoom;
 class ClientSession;
@@ -6,29 +7,40 @@ class ClientSession;
 class Player
 {
 public:
+	Player();
+	~Player() = default;
+
+public:
+	int32 GetPlayerId() const { return _id; }
+	void SetPlayerId(int32 id) { _id = id; }
+
+	int32 GetPlayerPosX() const { return _posX; }
+	void SetPlayerPosX(int32 x) { _posX = x; }
+	int32 GetPlayerPosY() const { return _posY; }
+	void SetPlayerPosY(int32 y) { _posY = y; }
+
+	std::string GetPlayerName() const { return _name; }
+	ObjectState GetPlayerState() const { return _state; }
+	MoveDir GetPlayerMoveDir() const { return _moveDir; }
+
+
+	void SetPlayerInfo(int32 id, std::string name, int32 posX, int32 posY, ObjectState state, MoveDir moveDir);
+
 	shared_ptr<GameRoom> GetGameRoom() const;
 	void SetGameRoom(shared_ptr<GameRoom> room);
 
 	shared_ptr<ClientSession> GetClientSession() const;
 	void SetClientSession(shared_ptr<ClientSession> session);
 
-	int32 GetPlayerId() const;
-	std::string GetPlayerName() const;
-	int32 GetPlayerPosX() const;
-	int32 GetPlayerPosY() const;
-	ObjectState GetPlayerState() const;
-	MoveDir GetPlayerMoveDir() const;
-	void SetPlayerId(int32 id);
-	void SetPlayerInfo(int32 id, std::string name, int32 posX, int32 posY, ObjectState state, MoveDir moveDir);
-
 private:
+	int32 _id;
+	int32 _posX;
+	int32 _posY;
+	std::string _name;
+	ObjectState _state;
+	MoveDir _moveDir;
+	Vector2Int _cellPos;
+
 	shared_ptr<GameRoom> _room;
 	shared_ptr<ClientSession> _session;
-	int32 _id = 0;
-	std::string _name;
-	int32 _posX = 0;
-	int32 _posY = 0;
-	ObjectState _state = ObjectState_IDLE;
-	MoveDir _moveDir = MoveDir_NONE;
 };
-

--- a/2D_MMO_Server/GameServer/RoomManager.cpp
+++ b/2D_MMO_Server/GameServer/RoomManager.cpp
@@ -14,9 +14,10 @@ RoomManager& RoomManager::Instance()
 	return *_instance;
 }
 
-shared_ptr<GameRoom> RoomManager::Add()
+shared_ptr<GameRoom> RoomManager::Add(int32 mapId)
 {
 	shared_ptr<GameRoom> gameRoom = make_shared<GameRoom>();
+	gameRoom->Init(mapId);
 
 	WRITE_LOCK;
 	gameRoom->SetRoomId(_roomId);

--- a/2D_MMO_Server/GameServer/RoomManager.h
+++ b/2D_MMO_Server/GameServer/RoomManager.h
@@ -11,7 +11,7 @@ public:
 	RoomManager& operator=(const RoomManager&) = delete;
 
 public:
-	shared_ptr<GameRoom> Add();
+	shared_ptr<GameRoom> Add(int32 mapId);
 	bool Remove(uint32 roomId);
 	shared_ptr<GameRoom> Find(uint32 roomId);
 


### PR DESCRIPTION
## 📝 변경사항

서버에서 맵 파일을 로드하고 플레이어가 갈 수 있는 좌표인지 아닌지 검증 후 플레이어를 이동 시키는 기능

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 참고사항

1. 클라이언트에서 Common/MapData 경로에 맵 파일들을 생성
2. 서버에서 맵 아이디에 따라 맵을 로드
3. 갈 수 없는 부분의 좌표를 저장하기 위해 _collision, _player 이름의 2차원 배열에 좌표 저장
4. 플레이어가 갈 수 있는 좌표인지 아닌지 판별하여 플레이어 좌표 업데이트

Map.h, Map.cpp 파일들을 참고하여 주시기 바랍니다.
Common 폴더 안에 MapData 폴더 생성 후 테스트해 주시면 감사하겠습니다.
