### PR TITLE
[ADD] 서버 피격 동기화

### DIFF
--- a/2D_MMO_Server/GameServer/GameRoom.cpp
+++ b/2D_MMO_Server/GameServer/GameRoom.cpp
@@ -213,6 +213,12 @@ void GameRoom::HandleSkill(shared_ptr<Player> player, const C_SKILL* skillPkt)
         Broadcast(respondSkillPkt);
 
         // TODO: Damaged
+        Vector2Int skillPos = player->GetFrontCellPos(player->GetPlayerMoveDir());
+        shared_ptr<Player> target = _map->Find(skillPos);
+        if (target != nullptr)
+        {
+            cout << target->GetPlayerName() << " was hit by " << player->GetPlayerName() << "!" << endl;
+        }
     }
 }
 

--- a/2D_MMO_Server/GameServer/Map.cpp
+++ b/2D_MMO_Server/GameServer/Map.cpp
@@ -43,6 +43,7 @@ bool Map::ApplyMove(shared_ptr<Player> player, Vector2Int dest)
 	}
 
 	// 서버가 가지고 있는 맵 정보(좌표)에 플레이어 저장
+	// 움직이기 전 좌표에 플레이어 정보 삭제
 	{
 		int32 x = player->GetPlayerPosX() - GetMinX();
 		int32 y = GetMaxY() - player->GetPlayerPosY();
@@ -51,6 +52,8 @@ bool Map::ApplyMove(shared_ptr<Player> player, Vector2Int dest)
 			_players[y][x] = nullptr;
 		}
 	}
+
+	// 이동할 좌표에 플레이어 정보 저장
 	{
 		int32 x = dest.X - GetMinX();
 		int32 y = GetMaxY() - dest.Y;
@@ -110,4 +113,21 @@ void Map::LoadMap(int32 mapId, string path)
 		CRASH();
 		return;
 	}
+}
+
+shared_ptr<Player> Map::Find(Vector2Int cellPos)
+{
+	if (cellPos.X < GetMinX() || cellPos.X > GetMaxX())
+	{
+		return nullptr;
+	}
+	if (cellPos.Y < GetMinY() || cellPos.Y > GetMaxY())
+	{
+		return nullptr;
+	}
+
+	int32 x = cellPos.X - GetMinX();
+	int32 y = GetMaxY() - cellPos.Y;
+
+	return _players[y][x];
 }

--- a/2D_MMO_Server/GameServer/Map.h
+++ b/2D_MMO_Server/GameServer/Map.h
@@ -35,6 +35,7 @@ public:
 	bool CanGo(Vector2Int cellPos, bool checkObjects = true);
 	bool ApplyMove(shared_ptr<Player> player, Vector2Int dest);
 	void LoadMap(int32 mapId, string path = "../../Common/MapData");
+	shared_ptr<Player> Find(Vector2Int cellPos);
 
 	template<typename T>
 	void InitMatrix(vector<vector<T>>& matrix, uint32 x, uint32 y)

--- a/2D_MMO_Server/GameServer/Player.cpp
+++ b/2D_MMO_Server/GameServer/Player.cpp
@@ -13,6 +13,29 @@ Player::Player()
 {
 }
 
+Vector2Int Player::GetFrontCellPos(MoveDir dir)
+{
+	Vector2Int cellPos = Vector2Int(_posX, _posY);
+
+	switch (dir)
+	{
+	case MoveDir_UP:
+		cellPos = cellPos + Vector2Int::Up();
+		break;
+	case MoveDir_DOWN:
+		cellPos = cellPos + Vector2Int::Down();
+		break;
+	case MoveDir_LEFT:
+		cellPos = cellPos + Vector2Int::Left();
+		break;
+	case MoveDir_RIGHT:
+		cellPos = cellPos + Vector2Int::Right();
+		break;
+	}
+
+	return cellPos;
+}
+
 shared_ptr<GameRoom> Player::GetGameRoom() const
 {
 	return _room;

--- a/2D_MMO_Server/GameServer/Player.h
+++ b/2D_MMO_Server/GameServer/Player.h
@@ -11,6 +11,9 @@ public:
 	~Player() = default;
 
 public:
+	Vector2Int GetFrontCellPos(MoveDir dir);
+
+public:
 	int32 GetPlayerId() const { return _id; }
 	void SetPlayerId(int32 id) { _id = id; }
 
@@ -22,7 +25,6 @@ public:
 	std::string GetPlayerName() const { return _name; }
 	ObjectState GetPlayerState() const { return _state; }
 	MoveDir GetPlayerMoveDir() const { return _moveDir; }
-
 
 	void SetPlayerInfo(int32 id, std::string name, int32 posX, int32 posY, ObjectState state, MoveDir moveDir);
 


### PR DESCRIPTION
## 📝 변경사항

플레이어가 바라보는 방향 앞 쪽에 게임 오브젝트(플레이어, 몬스터)가 있는 상태에서 스킬을 사용하면 서버에서 피격 처리

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 참고사항

1. 클라이언트에서 플레이어가 스킬을 사용했을 때 스킬 패킷을 서버로 보냄
2. 게임 서버에서 로드한 맵 정보를 사용해 플레이어가 바라 보는 방향의 앞 쪽 좌표를 얻음
3. 그 좌표에 플레이어가 있다면 피격 처리

현재 플레이어만 피격 처리되어 있지만 추후에 플레이어가 아닌 몬스터 피격 처리할 예정입니다.
