### PR TITLE
[ADD] 서버 컨텐츠 데이터 json 파일 파싱

### DIFF
--- a/2D_MMO_Server/GameServer/ClientSession.cpp
+++ b/2D_MMO_Server/GameServer/ClientSession.cpp
@@ -15,7 +15,9 @@ void ClientSession::OnConnected()
 	shared_ptr<Player> myPlayer = ObjectManager::Instance().Add<Player>();
 	SetPlayer(myPlayer);
 
-	_player->SetObjectInfo(myPlayer->GetObjectId(), "Player " + to_string(myPlayer->GetObjectId()), 0, 0, ObjectState_IDLE, MoveDir_DOWN);
+	_player->SetObjectInfo(myPlayer->GetObjectId(), "Player " + to_string(myPlayer->GetObjectId()));
+	_player->SetPosInfo(0, 0, ObjectState_IDLE, MoveDir_DOWN);
+	_player->SetStatInfo(_player->GetObjectHP(), _player->GetObjectMaxHP(), _player->GetObjectSpeed());
 	_player->SetClientSession(static_pointer_cast<ClientSession>(shared_from_this()));
 
 	RoomManager::Instance().Find(1)->EnterGame(_player);

--- a/2D_MMO_Server/GameServer/ConfigManager.h
+++ b/2D_MMO_Server/GameServer/ConfigManager.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "pch.h"
 
 class ServerConfig
 {
@@ -12,7 +13,7 @@ public:
 public:
 	string GetIpAddr() const { return _ipAddr; }
 	string GetPort() const { return _port; }
-	string GetdataPath() const { return _dataPath; }
+	string GetDataPath() const { return _dataPath; }
 
 private:
 	string _ipAddr;
@@ -29,8 +30,9 @@ public:
 public:
 	static ConfigManager LoadConfig();
 
-public:
 	ServerConfig GetServerConfig() const { return _config; }
+
+private:
 	void SetServerConfig(ServerConfig config) { _config = config; }
 
 private:

--- a/2D_MMO_Server/GameServer/ContentsData.cpp
+++ b/2D_MMO_Server/GameServer/ContentsData.cpp
@@ -1,0 +1,73 @@
+#include "pch.h"
+#include "ContentsData.h"
+#include <fstream>
+#include <nlohmann/json.hpp>
+
+map<uint32, Stat> StatData::MakeData()
+{
+    map<uint32, Stat> statData;
+
+    for (Stat stat : _stats)
+    {
+        statData.insert(make_pair(stat.Level, stat));
+    }
+
+    return statData;
+}
+
+StatData StatData::fromJson(const json& json)
+{
+    StatData statData;
+    Stat stat;
+
+    for (auto iter = json["stats"].begin(); iter != json["stats"].end(); ++iter)
+    {
+        stat.Level = iter->at("Level").get<uint32>();
+        stat.MaxHp = iter->at("MaxHp").get<uint32>();
+        stat.Attack = iter->at("Attack").get<uint32>();
+        stat.TotalExp = iter->at("TotalExp").get<uint32>();
+        statData._stats.push_back(stat);
+    }
+
+    return statData;
+}
+
+map<uint32, Skill> SkillData::MakeData()
+{
+    map<uint32, Skill> skillData;
+
+    for (Skill skill : _skills)
+    {
+        skillData.insert(make_pair(skill.ID, skill));
+    }
+
+    return skillData;
+}
+
+SkillData SkillData::fromJson(const json& json)
+{
+    SkillData skillData;
+    Skill skill;
+
+    for (auto iter = json["skills"].begin(); iter != json["skills"].end(); ++iter)
+    {
+        skill.ID = iter->at("ID").get<uint32>();
+        skill.Name = iter->at("Name").get<string>();
+        skill.CoolTime = iter->at("CoolTime").get<float>();
+        skill.Damage = iter->at("Damage").get<uint32>();
+        skill.SkillType = iter->at("SkillType").get<SkillType>();
+
+        if (iter->contains("Projectile"))
+        {
+            auto projectile = iter->find("Projectile");
+            skill.Projectile.Name = projectile->at("Name").get<string>();
+            skill.Projectile.Speed = projectile->at("Speed").get<float>();
+            skill.Projectile.Range = projectile->at("Range").get<uint32>();
+            skill.Projectile.Prefab = projectile->at("Prefab").get<string>();
+        }
+
+        skillData._skills.push_back(skill);
+    }
+
+    return skillData;
+}

--- a/2D_MMO_Server/GameServer/ContentsData.h
+++ b/2D_MMO_Server/GameServer/ContentsData.h
@@ -1,0 +1,70 @@
+#pragma once
+#include "DataManager.h"
+
+#pragma region Stat
+class Stat
+{
+public:
+	uint32 Level = 0;
+	uint32 MaxHp = 0;
+	uint32 Attack = 0;
+	uint32 TotalExp = 0;
+};
+
+class StatData : public ILoader<uint32, Stat>
+{
+public:
+	map<uint32, Stat> MakeData() override;
+
+	static StatData fromJson(const json& json);
+
+private:
+	vector<Stat> _stats;
+};
+#pragma endregion
+
+#pragma region Skill
+enum SkillType
+{
+	SKILL_NONE,
+	SKILL_AUTO,
+	SKILL_PROJECTILE
+};
+
+NLOHMANN_JSON_SERIALIZE_ENUM(SkillType, {
+	{SKILL_NONE, nullptr},
+	{SKILL_AUTO, "SkillAuto"},
+	{SKILL_PROJECTILE, "SkillProjectile"}
+	})
+
+	class ProjectileInfo
+{
+public:
+	string Name;
+	float Speed = 0;
+	uint32 Range = 0;
+	string Prefab;
+};
+
+class Skill
+{
+public:
+	uint32 ID = 0;
+	string Name;
+	float CoolTime = 0;
+	uint32 Damage = 0;
+	SkillType SkillType = SkillType::SKILL_NONE;
+	ProjectileInfo Projectile;
+};
+
+class SkillData : public ILoader<uint32, Skill>
+{
+public:
+	map<uint32, Skill> MakeData() override;
+
+	static SkillData fromJson(const json& json);
+
+private:
+	vector<Skill> _skills;
+};
+#pragma endregion

--- a/2D_MMO_Server/GameServer/DataManager.cpp
+++ b/2D_MMO_Server/GameServer/DataManager.cpp
@@ -1,0 +1,14 @@
+#include "pch.h"
+#include "DataManager.h"
+#include "ContentsData.h"
+
+map<uint32, Stat> DataManager::Stats;
+map<uint32, Skill> DataManager::Skills;
+
+void DataManager::LoadData()
+{
+	auto loadedStats = LoadJson<StatData>("StatData").MakeData();
+	auto loadedSkills = LoadJson<SkillData>("SkillData").MakeData();
+	Stats.insert(loadedStats.begin(), loadedStats.end());
+	Skills.insert(loadedSkills.begin(), loadedSkills.end());
+}

--- a/2D_MMO_Server/GameServer/DataManager.h
+++ b/2D_MMO_Server/GameServer/DataManager.h
@@ -1,0 +1,39 @@
+#pragma once
+#include "pch.h"
+#include <fstream>
+#include <nlohmann/json.hpp>
+#include "ConfigManager.h"
+
+class Stat;
+class Skill;
+
+template<typename Key, typename Value>
+class ILoader
+{
+public:
+	virtual map<Key, Value> MakeData() = 0;
+};
+
+class DataManager
+{
+public:
+	static void LoadData();
+
+private:
+	template<typename Loader>
+	static Loader LoadJson(string path)
+	{
+		ConfigManager config = ConfigManager::LoadConfig();
+
+		string fileName = path + ".json";
+		string filePath = config.GetServerConfig().GetDataPath() + "/" + fileName;
+		ifstream f(filePath);
+
+		json data = json::parse(f);
+		return Loader::fromJson(data);
+	}
+
+public:
+	static map<uint32, Stat> Stats;
+	static map<uint32, Skill> Skills;
+};

--- a/2D_MMO_Server/GameServer/GameObject.cpp
+++ b/2D_MMO_Server/GameServer/GameObject.cpp
@@ -9,6 +9,9 @@ GameObject::GameObject()
 	, _state(ObjectState_IDLE)
 	, _moveDir(MoveDir_DOWN)
 	, _cellPos(0, 0)
+	, _hp(0)
+	, _maxHp(0)
+	, _speed(0)
 	, _room(nullptr)
 {
 }
@@ -65,12 +68,23 @@ void GameObject::Update()
 {
 }
 
-void GameObject::SetObjectInfo(int32 id, std::string name, int32 posX, int32 posY, ObjectState state, MoveDir moveDir)
+void GameObject::SetObjectInfo(int32 id, std::string name)
 {
 	_id = id;
 	_name = name;
+}
+
+void GameObject::SetPosInfo(int32 posX, int32 posY, ObjectState state, MoveDir moveDir)
+{
 	_posX = posX;
 	_posY = posY;
 	_state = state;
 	_moveDir = moveDir;
+}
+
+void GameObject::SetStatInfo(int32 hp, int32 maxHp, float speed)
+{
+	_hp = hp;
+	_maxHp = maxHp;
+	_speed = speed;
 }

--- a/2D_MMO_Server/GameServer/GameObject.h
+++ b/2D_MMO_Server/GameServer/GameObject.h
@@ -22,6 +22,7 @@ public:
 	Vector2Int GetFrontCellPos();
 	static MoveDir GetDirFromVector(Vector2Int vector);
 	virtual void Update();
+	virtual void OnDamaged(shared_ptr<GameObject> attacker, int32 damage) = 0;
 
 public:
 	ObjectType GetObjectType() const { return _type; }
@@ -41,7 +42,14 @@ public:
 	MoveDir GetObjectMoveDir() const { return _moveDir; }
 	void SetObjectMoveDir(MoveDir moveDir) { _moveDir = moveDir; }
 
-	void SetObjectInfo(int32 id, std::string name, int32 posX, int32 posY, ObjectState state, MoveDir moveDir);
+	int32 GetObjectHP() const { return _hp; }
+	int32 GetObjectMaxHP() const { return _maxHp; }
+	float GetObjectSpeed() const { return _speed; }
+	void SetObjectSpeed(float speed) { _speed = speed; }
+
+	void SetObjectInfo(int32 id, std::string name);
+	void SetPosInfo(int32 posX, int32 posY, ObjectState state, MoveDir moveDir);
+	void SetStatInfo(int32 hp, int32 maxHp, float speed);
 
 	shared_ptr<GameRoom> GetGameRoom() const { return _room; }
 	void SetGameRoom(shared_ptr<GameRoom> room) { _room = room; }
@@ -55,6 +63,10 @@ protected:
 	ObjectState _state;
 	MoveDir _moveDir;
 	Vector2Int _cellPos;
+
+	int32 _hp;
+	int32 _maxHp;
+	float _speed;
 
 	shared_ptr<GameRoom> _room;
 };

--- a/2D_MMO_Server/GameServer/GameServer.cpp
+++ b/2D_MMO_Server/GameServer/GameServer.cpp
@@ -9,6 +9,7 @@
 #include "GameRoom.h"
 #include "ConfigManager.h"
 #include "StringConverter.h"
+#include "DataManager.h"
 
 int main()
 {
@@ -32,6 +33,8 @@ int main()
 
 	// GameServer Listening
 	ConfigManager config = ConfigManager::LoadConfig();
+	DataManager::LoadData();
+
 	RoomManager::Instance().Add(1); // Temp 1¹ø ¸Ê ·Îµå
 
 	wstring ipAddr = StringConverter::ConvertStringToWString(config.GetServerConfig().GetIpAddr().c_str(), config.GetServerConfig().GetIpAddr().size());

--- a/2D_MMO_Server/GameServer/GameServer.vcxproj
+++ b/2D_MMO_Server/GameServer/GameServer.vcxproj
@@ -178,6 +178,8 @@
     <ClCompile Include="ClientSession.cpp" />
     <ClCompile Include="ClientSessionManager.cpp" />
     <ClCompile Include="ConfigManager.cpp" />
+    <ClCompile Include="ContentsData.cpp" />
+    <ClCompile Include="DataManager.cpp" />
     <ClCompile Include="DBSession.cpp" />
     <ClCompile Include="GameObject.cpp" />
     <ClCompile Include="GameRoom.cpp" />
@@ -201,6 +203,8 @@
     <ClInclude Include="ClientSession.h" />
     <ClInclude Include="ClientSessionManager.h" />
     <ClInclude Include="ConfigManager.h" />
+    <ClInclude Include="ContentsData.h" />
+    <ClInclude Include="DataManager.h" />
     <ClInclude Include="DBSession.h" />
     <ClInclude Include="GameObject.h" />
     <ClInclude Include="GameRoom.h" />

--- a/2D_MMO_Server/GameServer/GameServer.vcxproj.filters
+++ b/2D_MMO_Server/GameServer/GameServer.vcxproj.filters
@@ -78,6 +78,12 @@
     <ClCompile Include="StringConverter.cpp">
       <Filter>Utils</Filter>
     </ClCompile>
+    <ClCompile Include="ContentsData.cpp">
+      <Filter>Game\Data</Filter>
+    </ClCompile>
+    <ClCompile Include="DataManager.cpp">
+      <Filter>Game\Data</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h">
@@ -124,6 +130,12 @@
     </ClInclude>
     <ClInclude Include="StringConverter.h">
       <Filter>Utils</Filter>
+    </ClInclude>
+    <ClInclude Include="ContentsData.h">
+      <Filter>Game\Data</Filter>
+    </ClInclude>
+    <ClInclude Include="DataManager.h">
+      <Filter>Game\Data</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/2D_MMO_Server/GameServer/Monster.cpp
+++ b/2D_MMO_Server/GameServer/Monster.cpp
@@ -18,6 +18,9 @@ Monster::Monster()
 
 	// TEMP
 	_state = ObjectState_IDLE;
+	_hp = 10;
+	_maxHp = 10;
+	_speed = 5.0f;
 
 	_searchCellDistance = static_cast<int32>(CellDistance::DEFAULT_SEARCH_DIST);
 	_chaseCellDistance = static_cast<int32>(CellDistance::DEFAULT_CHASE_DIST);
@@ -45,6 +48,11 @@ void Monster::Update()
 		UpdateDead();
 		break;
 	}
+}
+
+void Monster::OnDamaged(shared_ptr<GameObject> attacker, int32 damage)
+{
+	cout << "Damaged " << damage << "! From " << attacker->GetObjectName() << endl;
 }
 
 void Monster::BroadcastMove()
@@ -166,9 +174,12 @@ void Monster::UpdateSkill()
 
 		// TODO: 데미지
 		cout << _target->GetObjectName() << " was hit by " << _name << "!" << endl;
+		_target->OnDamaged(shared_from_this(), 10/*temp*/);
 
 		// 스킬 사용 Broadcast
-		SetObjectInfo(_id, _name, _posX, _posY, ObjectState_SKILL, _moveDir);
+		SetObjectInfo(_id, _name);
+		SetPosInfo(_posX, _posY, ObjectState_SKILL, _moveDir);
+		SetStatInfo(_hp, _maxHp, _speed);
 
 		flatbuffers::FlatBufferBuilder builder;
 		int32 skillId = 1; // TEMP

--- a/2D_MMO_Server/GameServer/Monster.h
+++ b/2D_MMO_Server/GameServer/Monster.h
@@ -11,6 +11,7 @@ public:
 
 public:
 	void Update() override;
+	void OnDamaged(shared_ptr<GameObject> attacker, int32 damage) override;
 	void BroadcastMove();
 
 protected:

--- a/2D_MMO_Server/GameServer/Player.cpp
+++ b/2D_MMO_Server/GameServer/Player.cpp
@@ -1,8 +1,20 @@
 #include "pch.h"
 #include "Player.h"
+#include "ContentsData.h"
+#include "DataManager.h"
 
 Player::Player()
 	: _session(nullptr)
 {
 	_type = ObjectType::PLAYER;
+
+	// TEMP
+	_hp = 100;
+	_maxHp = 100;
+	_speed = 10.0f;
+}
+
+void Player::OnDamaged(shared_ptr<GameObject> attacker, int32 damage)
+{
+	cout << "Damaged " << damage << "! From " << attacker->GetObjectName() << endl;
 }

--- a/2D_MMO_Server/GameServer/Player.h
+++ b/2D_MMO_Server/GameServer/Player.h
@@ -12,6 +12,9 @@ public:
 	~Player() = default;
 
 public:
+	void OnDamaged(shared_ptr<GameObject> attacker, int32 damage) override;
+
+public:
 	shared_ptr<ClientSession> GetClientSession() const { return _session; };
 	void SetClientSession(shared_ptr<ClientSession> session) { _session = session; }
 

--- a/Common/Data/ContentsData/SkillData.json
+++ b/Common/Data/ContentsData/SkillData.json
@@ -1,0 +1,24 @@
+{
+    "skills": [
+        {
+            "ID": 1,
+            "Name": "AutoAttack",
+            "CoolTime": 0.3,
+            "Damage": 20,
+            "SkillType": "SkillAuto"
+        },
+        {
+            "ID": 2,
+            "Name": "ArrowAttack",
+            "CoolTime": 0.2,
+            "Damage": 5,
+            "SkillType": "SkillProjectile",
+            "Projectile": {
+                "Name": "Arrow",
+                "Speed": 20.0,
+                "Range": 10,
+                "Prefab": "Arrow"
+            }
+        }
+    ]
+}

--- a/Common/Data/ContentsData/StatData.json
+++ b/Common/Data/ContentsData/StatData.json
@@ -1,10 +1,10 @@
 {
     "stats": [
       {
-        "level": "1",
-        "maxHp": "100",
-        "attack": "10",
-        "totalExp": "0"
+        "Level": 1,
+        "MaxHp": 100,
+        "Attack": 10,
+        "TotalExp": 0
       }
     ]
 }

--- a/Common/Data/config.json
+++ b/Common/Data/config.json
@@ -1,5 +1,5 @@
 {
   "ipAddr": "127.0.0.1",
   "port": "8002",
-  "dataPath": "ContentsData"
+  "dataPath": "../../Common/Data/ContentsData"
 }

--- a/Common/fbs/InGame.fbs
+++ b/Common/fbs/InGame.fbs
@@ -23,6 +23,7 @@ table ObjectInfo {
 	objectId:int32;
 	name:string;
 	posInfo:PositionInfo;
+	statInfo:StatInfo;
 }
 
 table PositionInfo {
@@ -30,6 +31,12 @@ table PositionInfo {
 	moveDir:MoveDir;
 	posX:int32;
 	posY:int32;
+}
+
+table StatInfo {
+	hp:int32;
+	maxHp:int32;
+	speed:float;
 }
 
 table SkillInfo {


### PR DESCRIPTION
## 📝 변경사항

컨텐츠 데이터에 해당하는 스킬 데이터, 스탯 데이터 json 파일들을 파싱하여 서버에서 처리

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 참고사항

2D_MMO/Common/Data/ContentsData 경로에 스탯, 스킬 데이터에 해당하는 json 파일들을 파싱하면 std::map에 정보들을 담아 관리합니다.

![Screenshot 2025-03-06 220916](https://github.com/user-attachments/assets/7637158d-bb6e-4d76-aa56-41d29631e287)

<br>

컨텐츠 데이터 json 파일 로드 후 사용
```
#include "ContentsData.h"
#include "DataManager.h"

// json 파일들을 파싱하면
// 스탯 데이터들은 DataManager::Stats,
// 스킬 데이터들은 DataManager::Skills에 담겨 있습니다.
DataManager::LoadData();

Skill skillData;
auto iter = DataManager::Skills.find(skillPkt->skillInfo()->skillId());
if (iter != DataManager::Skills.end())
    skillData = iter->second;
```

<br>

기존에 하드 코딩 되어 있던 스킬 아이디, 데미지 등의 수치들을 json 파일에서 수정해서 반영하도록 변경하였습니다.
```
// 변경 후 예시
GameRoom.cpp

// json으로부터 파싱한 스킬 정보에 따라 스킬 처리
Skill skillData;
auto iter = DataManager::Skills.find(skillPkt->skillInfo()->skillId());
if (iter != DataManager::Skills.end())
    skillData = iter->second;


switch (skillData.SkillType)
{
case SKILL_AUTO:
   break;
case SKILL_PROJECTILE:
    break;
case SKILL_NONE:
    return;
}
```

<br>

현재는 일반 공격의 데미지 수치만 반영할 수 있는데 추후에 스탯 수치들과 투사체 스킬 관련된 컨텐츠를 추가할 예정입니다.
```
{
    "skills": [
        {
            "ID": 1,
            "Name": "AutoAttack",
            "CoolTime": 0.3,
            "Damage": 20,
            "SkillType": "SkillAuto"
        },
--- 이하 생략 ---
```