### PR TITLE
[ADD]  서버 json 파일로 스탯 관리 및 데미지 판정

### DIFF
--- a/2D_MMO_Server/GameServer/ClientSession.cpp
+++ b/2D_MMO_Server/GameServer/ClientSession.cpp
@@ -6,6 +6,7 @@
 #include "GameRoom.h"
 #include "RoomManager.h"
 #include "PacketManager.h"
+#include "ContentsData.h"
 
 void ClientSession::OnConnected()
 {
@@ -15,9 +16,16 @@ void ClientSession::OnConnected()
 	shared_ptr<Player> myPlayer = ObjectManager::Instance().Add<Player>();
 	SetPlayer(myPlayer);
 
+	Stat statData;
+	auto iter = DataManager::Stats.find(1); // 레벨 1 시작
+	if (iter != DataManager::Stats.end())
+	{
+		statData = iter->second;
+	}
+
 	_player->SetObjectInfo(myPlayer->GetObjectId(), "Player " + to_string(myPlayer->GetObjectId()));
 	_player->SetPosInfo(0, 0, ObjectState_IDLE, MoveDir_DOWN);
-	_player->SetStatInfo(_player->GetObjectHP(), _player->GetObjectMaxHP(), _player->GetObjectSpeed());
+	_player->SetStatInfo(statData.Level, statData.Speed, statData.Hp, statData.MaxHp, statData.Attack, statData.TotalExp);
 	_player->SetClientSession(static_pointer_cast<ClientSession>(shared_from_this()));
 
 	RoomManager::Instance().Find(1)->EnterGame(_player);

--- a/2D_MMO_Server/GameServer/ContentsData.cpp
+++ b/2D_MMO_Server/GameServer/ContentsData.cpp
@@ -3,9 +3,9 @@
 #include <fstream>
 #include <nlohmann/json.hpp>
 
-map<uint32, Stat> StatData::MakeData()
+map<int32, Stat> StatData::MakeData()
 {
-    map<uint32, Stat> statData;
+    map<int32, Stat> statData;
 
     for (Stat stat : _stats)
     {
@@ -22,10 +22,12 @@ StatData StatData::fromJson(const json& json)
 
     for (auto iter = json["stats"].begin(); iter != json["stats"].end(); ++iter)
     {
-        stat.Level = iter->at("Level").get<uint32>();
-        stat.MaxHp = iter->at("MaxHp").get<uint32>();
-        stat.Attack = iter->at("Attack").get<uint32>();
-        stat.TotalExp = iter->at("TotalExp").get<uint32>();
+        stat.Level = iter->at("Level").get<int32>();
+        stat.Speed = iter->at("Speed").get<float>();
+        stat.MaxHp = iter->at("MaxHp").get<int32>();
+        stat.Hp = stat.MaxHp;
+        stat.Attack = iter->at("Attack").get<int32>();
+        stat.TotalExp = iter->at("TotalExp").get<int32>();
         statData._stats.push_back(stat);
     }
 

--- a/2D_MMO_Server/GameServer/ContentsData.h
+++ b/2D_MMO_Server/GameServer/ContentsData.h
@@ -5,16 +5,18 @@
 class Stat
 {
 public:
-	uint32 Level = 0;
-	uint32 MaxHp = 0;
-	uint32 Attack = 0;
-	uint32 TotalExp = 0;
+	int32 Level = 0;
+	float Speed = 0;
+	int32 Hp = 0;
+	int32 MaxHp = 0;
+	int32 Attack = 0;
+	int32 TotalExp = 0;
 };
 
-class StatData : public ILoader<uint32, Stat>
+class StatData : public ILoader<int32, Stat>
 {
 public:
-	map<uint32, Stat> MakeData() override;
+	map<int32, Stat> MakeData() override;
 
 	static StatData fromJson(const json& json);
 
@@ -24,17 +26,17 @@ private:
 #pragma endregion
 
 #pragma region Skill
-enum SkillType
-{
-	SKILL_NONE,
-	SKILL_AUTO,
-	SKILL_PROJECTILE
-};
+//enum SkillType
+//{
+//	SKILL_NONE,
+//	SKILL_AUTO,
+//	SKILL_PROJECTILE
+//};
 
 NLOHMANN_JSON_SERIALIZE_ENUM(SkillType, {
-	{SKILL_NONE, nullptr},
-	{SKILL_AUTO, "SkillAuto"},
-	{SKILL_PROJECTILE, "SkillProjectile"}
+	{SkillType_SKILL_NONE, nullptr},
+	{SkillType_SKILL_AUTO, "SKILL_AUTO"},
+	{SkillType_SKILL_PROJECTILE, "SKILL_PROJECTILE"}
 	})
 
 	class ProjectileInfo
@@ -53,7 +55,7 @@ public:
 	string Name;
 	float CoolTime = 0;
 	uint32 Damage = 0;
-	SkillType SkillType = SkillType::SKILL_NONE;
+	SkillType SkillType = SkillType_SKILL_NONE;
 	ProjectileInfo Projectile;
 };
 

--- a/2D_MMO_Server/GameServer/ContentsData.h
+++ b/2D_MMO_Server/GameServer/ContentsData.h
@@ -26,13 +26,6 @@ private:
 #pragma endregion
 
 #pragma region Skill
-//enum SkillType
-//{
-//	SKILL_NONE,
-//	SKILL_AUTO,
-//	SKILL_PROJECTILE
-//};
-
 NLOHMANN_JSON_SERIALIZE_ENUM(SkillType, {
 	{SkillType_SKILL_NONE, nullptr},
 	{SkillType_SKILL_AUTO, "SKILL_AUTO"},

--- a/2D_MMO_Server/GameServer/GameObject.cpp
+++ b/2D_MMO_Server/GameServer/GameObject.cpp
@@ -1,5 +1,7 @@
 #include "pch.h"
 #include "GameObject.h"
+#include "PacketManager.h"
+#include "GameRoom.h"
 
 GameObject::GameObject()
 	: _type(ObjectType::NONE)
@@ -9,9 +11,12 @@ GameObject::GameObject()
 	, _state(ObjectState_IDLE)
 	, _moveDir(MoveDir_DOWN)
 	, _cellPos(0, 0)
+	, _level(1)
+	, _speed(0)
 	, _hp(0)
 	, _maxHp(0)
-	, _speed(0)
+	, _attack(0)
+	, _totalExp(0)
 	, _room(nullptr)
 {
 }
@@ -68,6 +73,35 @@ void GameObject::Update()
 {
 }
 
+void GameObject::OnDamaged(shared_ptr<GameObject> attacker, int32 damage)
+{
+	if (_room == nullptr)
+	{
+		CRASH();
+	}
+
+	// hp가 음수가 되지 못하도록 함
+	_hp = std::max(_hp - damage, 0);
+
+	// Broadcast
+	{
+		flatbuffers::FlatBufferBuilder builder;
+		auto changeHp = CreateSC_CHANGE_HP(builder, _id, _hp);
+		auto changeHpPkt = PacketManager::Instance().CreatePacket(changeHp, builder, PacketType_SC_CHANGE_HP);
+		_room->Broadcast(changeHpPkt);
+	}
+
+	if (_hp <= 0)
+	{
+		OnDead(attacker);
+	}
+}
+
+void GameObject::OnDead(shared_ptr<GameObject> attacker)
+{
+
+}
+
 void GameObject::SetObjectInfo(int32 id, std::string name)
 {
 	_id = id;
@@ -82,9 +116,12 @@ void GameObject::SetPosInfo(int32 posX, int32 posY, ObjectState state, MoveDir m
 	_moveDir = moveDir;
 }
 
-void GameObject::SetStatInfo(int32 hp, int32 maxHp, float speed)
+void GameObject::SetStatInfo(int32 level, float speed, int32 hp, int32 maxHp, int32 attack, int32 totalExp)
 {
+	_level = level;
+	_speed = speed;
 	_hp = hp;
 	_maxHp = maxHp;
-	_speed = speed;
+	_attack = attack;
+	_totalExp = totalExp;
 }

--- a/2D_MMO_Server/GameServer/GameObject.h
+++ b/2D_MMO_Server/GameServer/GameObject.h
@@ -22,7 +22,8 @@ public:
 	Vector2Int GetFrontCellPos();
 	static MoveDir GetDirFromVector(Vector2Int vector);
 	virtual void Update();
-	virtual void OnDamaged(shared_ptr<GameObject> attacker, int32 damage) = 0;
+	virtual void OnDamaged(shared_ptr<GameObject> attacker, int32 damage);
+	virtual void OnDead(shared_ptr<GameObject> attacker);
 
 public:
 	ObjectType GetObjectType() const { return _type; }
@@ -42,14 +43,17 @@ public:
 	MoveDir GetObjectMoveDir() const { return _moveDir; }
 	void SetObjectMoveDir(MoveDir moveDir) { _moveDir = moveDir; }
 
+	int32 GetOjbectLevel() const { return _level; }
 	int32 GetObjectHP() const { return _hp; }
 	int32 GetObjectMaxHP() const { return _maxHp; }
+	int32 GetObjectAttack() const { return _attack; }
+	int32 GetObjectTotalExp() const { return _totalExp; }
 	float GetObjectSpeed() const { return _speed; }
 	void SetObjectSpeed(float speed) { _speed = speed; }
 
 	void SetObjectInfo(int32 id, std::string name);
 	void SetPosInfo(int32 posX, int32 posY, ObjectState state, MoveDir moveDir);
-	void SetStatInfo(int32 hp, int32 maxHp, float speed);
+	void SetStatInfo(int32 level, float speed, int32 hp, int32 maxHp, int32 attack, int32 totalExp);
 
 	shared_ptr<GameRoom> GetGameRoom() const { return _room; }
 	void SetGameRoom(shared_ptr<GameRoom> room) { _room = room; }
@@ -64,9 +68,12 @@ protected:
 	MoveDir _moveDir;
 	Vector2Int _cellPos;
 
+	int32 _level;
+	float _speed;
 	int32 _hp;
 	int32 _maxHp;
-	float _speed;
+	int32 _attack;
+	int32 _totalExp;
 
 	shared_ptr<GameRoom> _room;
 };

--- a/2D_MMO_Server/GameServer/GameRoom.cpp
+++ b/2D_MMO_Server/GameServer/GameRoom.cpp
@@ -29,7 +29,7 @@ void GameRoom::Init(int32 mapId)
         shared_ptr<Monster> monster = ObjectManager::Instance().Add<Monster>();
         monster->SetObjectInfo(monster->GetObjectId(), "MONSTER_" + to_string(monster->GetObjectId()));
         monster->SetPosInfo(9, -9, ObjectState_IDLE, MoveDir_DOWN);
-        monster->SetStatInfo(monster->GetObjectHP(), monster->GetObjectMaxHP(), monster->GetObjectSpeed());
+        monster->SetStatInfo(monster->GetOjbectLevel(), monster->GetObjectSpeed(), monster->GetObjectHP(), monster->GetObjectMaxHP(), monster->GetObjectAttack(), monster->GetObjectTotalExp());
         EnterGame(monster);
     }
 }
@@ -286,7 +286,6 @@ void GameRoom::HandleSkill(shared_ptr<Player> player, const C_SKILL* skillPkt)
 
         Broadcast(respondSkillPkt);
 
-        // json으로부터 파싱한 스킬 정보에 따라 스킬 처리
         Skill skillData;
         auto iter = DataManager::Skills.find(skillPkt->skillInfo()->skillId());
         if (iter != DataManager::Skills.end())
@@ -296,7 +295,7 @@ void GameRoom::HandleSkill(shared_ptr<Player> player, const C_SKILL* skillPkt)
 
         switch (skillData.SkillType)
         {
-        case SKILL_AUTO:
+        case SkillType_SKILL_AUTO:
         {
             Vector2Int skillPos = player->GetFrontCellPos(player->GetObjectMoveDir());
             shared_ptr<GameObject> target = _map->Find(skillPos);
@@ -308,17 +307,17 @@ void GameRoom::HandleSkill(shared_ptr<Player> player, const C_SKILL* skillPkt)
                     return;
                 }
 
-                cout << target->GetObjectName() << " was hit by " << player->GetObjectName() << "!" << endl;
-                target->OnDamaged(player, skillData.Damage);
+                cout << target->GetObjectName() << " was hit!" << endl;
+                target->OnDamaged(player, skillData.Damage + player->GetObjectAttack()/*스킬 공격력 + 플레이어 공격력*/);
             }
         }
         break;
 
-        case SKILL_PROJECTILE:
+        case SkillType_SKILL_PROJECTILE:
             // TODO: Arrow Attack
             break;
 
-        case SKILL_NONE:
+        case SkillType_SKILL_NONE:
             return;
         }
     }

--- a/2D_MMO_Server/GameServer/Monster.h
+++ b/2D_MMO_Server/GameServer/Monster.h
@@ -12,6 +12,7 @@ public:
 public:
 	void Update() override;
 	void OnDamaged(shared_ptr<GameObject> attacker, int32 damage) override;
+	void OnDead(shared_ptr<GameObject> attacker) override;
 	void BroadcastMove();
 
 protected:
@@ -34,10 +35,10 @@ private:
 	uint64 _nextPatrolTick;
 	uint64 _nextSearchTick;
 	uint64 _nextMoveTick;
-	uint64 _skillCoolTick;
 	int32 _searchCellDistance;
 	int32 _chaseCellDistance;
 	int32 _skillRange;
+	int32 _skillCoolTick;
 
 	Vector2Int _destPos;
 	shared_ptr<Player> _target;

--- a/2D_MMO_Server/GameServer/Player.cpp
+++ b/2D_MMO_Server/GameServer/Player.cpp
@@ -1,20 +1,20 @@
 #include "pch.h"
 #include "Player.h"
 #include "ContentsData.h"
-#include "DataManager.h"
 
 Player::Player()
 	: _session(nullptr)
 {
 	_type = ObjectType::PLAYER;
-
-	// TEMP
-	_hp = 100;
-	_maxHp = 100;
-	_speed = 10.0f;
 }
 
 void Player::OnDamaged(shared_ptr<GameObject> attacker, int32 damage)
 {
-	cout << "Damaged " << damage << "! From " << attacker->GetObjectName() << endl;
+	GameObject::OnDamaged(attacker, damage);
+
+}
+
+void Player::OnDead(shared_ptr<GameObject> attacker)
+{
+
 }

--- a/2D_MMO_Server/GameServer/Player.h
+++ b/2D_MMO_Server/GameServer/Player.h
@@ -13,6 +13,7 @@ public:
 
 public:
 	void OnDamaged(shared_ptr<GameObject> attacker, int32 damage) override;
+	void OnDead(shared_ptr<GameObject> attacker) override;
 
 public:
 	shared_ptr<ClientSession> GetClientSession() const { return _session; };

--- a/Common/Data/ContentsData/SkillData.json
+++ b/Common/Data/ContentsData/SkillData.json
@@ -4,15 +4,15 @@
             "ID": 1,
             "Name": "AutoAttack",
             "CoolTime": 0.3,
-            "Damage": 20,
-            "SkillType": "SkillAuto"
+            "Damage": 10,
+            "SkillType": "SKILL_AUTO"
         },
         {
             "ID": 2,
             "Name": "ArrowAttack",
             "CoolTime": 0.2,
             "Damage": 5,
-            "SkillType": "SkillProjectile",
+            "SkillType": "SKILL_PROJECTILE",
             "Projectile": {
                 "Name": "Arrow",
                 "Speed": 20.0,

--- a/Common/Data/ContentsData/StatData.json
+++ b/Common/Data/ContentsData/StatData.json
@@ -2,9 +2,24 @@
     "stats": [
       {
         "Level": 1,
+        "Speed": 9,
         "MaxHp": 100,
+        "Attack": 5,
+        "TotalExp": 10
+      },
+      {
+        "Level": 2,
+        "Speed": 9,
+        "MaxHp": 150,
         "Attack": 10,
-        "TotalExp": 0
+        "TotalExp": 20
+      },
+      {
+        "Level": 3,
+        "Speed": 9,
+        "MaxHp": 200,
+        "Attack": 15,
+        "TotalExp": 30
       }
     ]
 }

--- a/Common/fbs/InGame.fbs
+++ b/Common/fbs/InGame.fbs
@@ -19,6 +19,12 @@ enum GameObjectType : byte {
     PROJECTILE
 }
 
+enum SkillType : byte {
+    SKILL_NONE,
+    SKILL_AUTO,
+    SKILL_PROJECTILE
+}
+
 table ObjectInfo {
 	objectId:int32;
 	name:string;
@@ -74,4 +80,9 @@ table C_SKILL {
 table SC_SKILL {
 	objectId:int32;
 	skillInfo:SkillInfo;
+}
+
+table SC_CHANGE_HP {
+	objectId:int32;
+	hp:int32;
 }

--- a/Common/fbs/Protocol.fbs
+++ b/Common/fbs/Protocol.fbs
@@ -12,4 +12,5 @@ union PacketType {
 	SC_CHAT,
 	C_SKILL,
 	SC_SKILL,
+	SC_CHANGE_HP
 }


### PR DESCRIPTION
## 📝 변경사항

서버에서 플레이어 스탯을 json 파일로 관리하도록 변경하고 데미지 판정 구현

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 참고사항

기존에 하드 코딩 되어 있던 플레이어 스탯 수치들을 json 파일에서 수정해서 반영하도록 변경하였습니다.

```
// 변경 후 예시
ClientSession.cpp

Stat statData;
	auto iter = DataManager::Stats.find(1); // 1레벨로 시작
	if (iter != DataManager::Stats.end())
	{
		statData = iter->second;
	}

	_player->SetObjectInfo(myPlayer->GetObjectId(), "Player " + to_string(myPlayer->GetObjectId()));
	_player->SetStatInfo(statData.Level, statData.Speed, statData.Hp, statData.MaxHp, statData.Attack, statData.TotalExp);
```

<br>

서버와 클라이언트에서 공통적으로 스킬 타입을 사용할 예정이라 enum 타입의 SkillType을 플랫버퍼 파일로 옮겼습니다.
```
InGame.fbs

// 생략

enum GameObjectType : byte {
    NONE,
    PLAYER,
    MONSTER,
    PROJECTILE
}

enum SkillType : byte {
    SKILL_NONE,
    SKILL_AUTO,
    SKILL_PROJECTILE
}

table ObjectInfo {
	objectId:int32;
	name:string;
	posInfo:PositionInfo;
	statInfo:StatInfo;
}

// 생략
```

<br>

* 데미지 판정
```
void GameObject::OnDamaged(shared_ptr<GameObject> attacker, int32 damage)
{
	if (_room == nullptr)
	{
		CRASH();
	}

	// hp가 음수가 되지 못하도록 함
	_hp = std::max(_hp - damage, 0);

	// Broadcast
	{
		flatbuffers::FlatBufferBuilder builder;
		auto changeHp = CreateSC_CHANGE_HP(builder, _id, _hp);
		auto changeHpPkt = PacketManager::Instance().CreatePacket(changeHp, builder, PacketType_SC_CHANGE_HP);
		_room->Broadcast(changeHpPkt);
	}

	if (_hp <= 0)
	{
		OnDead(attacker);
	}
}
```
![Image](https://github.com/user-attachments/assets/7d1b1808-16dd-4d63-8b43-0fdc745acea5)
