### PR TITLE
[ADD] 서버 플레이어, 몬스터 죽음 후 리스폰 처리

### DIFF
--- a/2D_MMO_Server/GameServer/GameObject.cpp
+++ b/2D_MMO_Server/GameServer/GameObject.cpp
@@ -99,7 +99,10 @@ void GameObject::OnDamaged(shared_ptr<GameObject> attacker, int32 damage)
 
 void GameObject::OnDead(shared_ptr<GameObject> attacker)
 {
-
+	flatbuffers::FlatBufferBuilder builder;
+	auto die = CreateSC_DIE(builder, _id, attacker->GetObjectId());
+	auto diePkt = PacketManager::Instance().CreatePacket(die, builder, PacketType_SC_DIE);
+	_room->Broadcast(diePkt);
 }
 
 void GameObject::SetObjectInfo(int32 id, std::string name)

--- a/2D_MMO_Server/GameServer/Monster.cpp
+++ b/2D_MMO_Server/GameServer/Monster.cpp
@@ -63,6 +63,22 @@ void Monster::OnDamaged(shared_ptr<GameObject> attacker, int32 damage)
 
 void Monster::OnDead(shared_ptr<GameObject> attacker)
 {
+	GameObject::OnDead(attacker);
+
+	shared_ptr<GameRoom> room = _room;
+	room->LeaveGame(_id);
+
+	// 일정 시간 후 리스폰
+	// 애니메이션 재생 후 바로 몬스터가 사라져야해서 LeaveGame() 과 EnterGame() 사이에 위치
+	this_thread::sleep_for(1.5s);
+
+	// 몬스터 정보 리셋
+	SetObjectInfo(_id, "Monster " + to_string(_id));
+	_hp = _maxHp;
+	SetPosInfo(9, -9, ObjectState_IDLE, MoveDir_DOWN);
+	SetStatInfo(_level, _speed, _hp, _maxHp, _attack, _totalExp);
+
+	room->EnterGame(shared_from_this());
 }
 
 void Monster::BroadcastMove()

--- a/2D_MMO_Server/GameServer/Player.cpp
+++ b/2D_MMO_Server/GameServer/Player.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 #include "Player.h"
 #include "ContentsData.h"
+#include "GameRoom.h"
 
 Player::Player()
 	: _session(nullptr)
@@ -16,5 +17,19 @@ void Player::OnDamaged(shared_ptr<GameObject> attacker, int32 damage)
 
 void Player::OnDead(shared_ptr<GameObject> attacker)
 {
+	GameObject::OnDead(attacker);
 
+	// 클라이언트에서 애니메이션 재생 후 리스폰
+	this_thread::sleep_for(1.5s);
+
+	shared_ptr<GameRoom> room = _room;
+	room->LeaveGame(_id);
+
+	// 플레이어 정보 리셋
+	SetObjectInfo(_id, "Player " + to_string(_id));
+	_hp = _maxHp;
+	SetPosInfo(0, 0, ObjectState_IDLE, MoveDir_DOWN);
+	SetStatInfo(_level, _speed, _hp, _maxHp, _attack, _totalExp);
+
+	room->EnterGame(shared_from_this());
 }

--- a/Common/fbs/InGame.fbs
+++ b/Common/fbs/InGame.fbs
@@ -86,3 +86,8 @@ table SC_CHANGE_HP {
 	objectId:int32;
 	hp:int32;
 }
+
+table SC_DIE {
+	objectId:int32;
+	attackerId:int32;
+}

--- a/Common/fbs/Protocol.fbs
+++ b/Common/fbs/Protocol.fbs
@@ -12,5 +12,6 @@ union PacketType {
 	SC_CHAT,
 	C_SKILL,
 	SC_SKILL,
-	SC_CHANGE_HP
+	SC_CHANGE_HP,
+	SC_DIE
 }


### PR DESCRIPTION
## 📝 변경사항

서버에서 게임 오브젝트에 해당하는 플레이어와 몬스터 죽음 후 리스폰 처리

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 참고사항

SC_DIE 패킷을 통해 게임 오브젝트 아이디로 자신이 죽었다는 것을 클라이언트에 전송하고 특정 좌표에 플레이어와 몬스터가 리스폰 될 수 있도록 하였습니다.

```
// 예시
flatbuffers::FlatBufferBuilder builder;
auto die = CreateSC_DIE(builder, _id, attacker->GetObjectId());
auto diePkt = PacketManager::Instance().CreatePacket(die, builder, PacketType_SC_DIE);
_room->Broadcast(diePkt);

SetObjectInfo(_id, "Player " + to_string(_id));
SetPosInfo(0, 0, ObjectState_IDLE, MoveDir_DOWN);
SetStatInfo(_level, _speed, _hp, _maxHp, _attack, _totalExp);
```

![Image](https://github.com/user-attachments/assets/12634850-5845-49e5-911c-fef72eb2ee51)
